### PR TITLE
update NPU documentation and LlamaFactory branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# LLaMA-Factory Document
+# LlamaFactory Document
 
-Document for https://github.com/hiyouga/LLaMA-Factory
+Document for https://github.com/hiyouga/LlamaFactory
 
 Visit https://llamafactory.readthedocs.io/ for the document.
 

--- a/docs/locales/en/LC_MESSAGES/advanced/acceleration.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/acceleration.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -24,10 +24,10 @@ msgstr "Acceleration"
 
 #: ../../source/advanced/acceleration.rst:4 86f71382feb54ad3a56260b1c208cf58
 msgid ""
-"LLaMA-Factory 支持多种加速技术，包括：:ref:`FlashAttention <flashattn>` 、 "
+"LlamaFactory 支持多种加速技术，包括：:ref:`FlashAttention <flashattn>` 、 "
 ":ref:`Unsloth <sloth>` 、 :ref:`Liger Kernel <ligerkernel>`  。"
 msgstr ""
-"LLaMA-Factory supports multiple acceleration techniques, including: :ref:`FlashAttention <flashattn>`, "
+"LlamaFactory supports multiple acceleration techniques, including: :ref:`FlashAttention <flashattn>`, "
 ":ref:`Unsloth <sloth>`, :ref:`Liger Kernel <ligerkernel>`."
 
 #: ../../source/advanced/acceleration.rst:13 df4db3178001448291a4ae64f3d93d5f

--- a/docs/locales/en/LC_MESSAGES/advanced/arguments.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/arguments.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -1418,9 +1418,9 @@ msgstr "dataset_dir"
 
 #: ../../source/advanced/arguments.rst:406 231f08bfaf0a4e138f72cc949f1b1a8a
 msgid ""
-"存储数据集的文件夹路径，可以是字符串或字典。当为字符串时，表示数据集目录的路径，例如 `data <https://github.com/hiyouga/LLaMA-Factory/tree/main/data>`_ ；当为字典时，将覆盖默认从本地 `dataset_info.json <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dataset_info.json>`_ 加载的行为。"
+"存储数据集的文件夹路径，可以是字符串或字典。当为字符串时，表示数据集目录的路径，例如 `data <https://github.com/hiyouga/LlamaFactory/tree/main/data>`_ ；当为字典时，将覆盖默认从本地 `dataset_info.json <https://github.com/hiyouga/LlamaFactory/blob/main/data/dataset_info.json>`_ 加载的行为。"
 msgstr ""
-"The path to the folder storing the dataset, which can be a string or a dictionary. If a string, it represents the dataset directory path, for example `data <https://github.com/hiyouga/LLaMA-Factory/tree/main/data>`_ ; if a dictionary, it overrides the default behavior of loading from the local `dataset_info.json <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dataset_info.json>`_."
+"The path to the folder storing the dataset, which can be a string or a dictionary. If a string, it represents the dataset directory path, for example `data <https://github.com/hiyouga/LlamaFactory/tree/main/data>`_ ; if a dictionary, it overrides the default behavior of loading from the local `dataset_info.json <https://github.com/hiyouga/LlamaFactory/blob/main/data/dataset_info.json>`_."
 
 #: ../../source/advanced/arguments.rst:410 2acd56ebb48b4d9ebf4e23c5ee547c8a
 msgid "media_dir"
@@ -2638,8 +2638,8 @@ msgstr "Forces checking of optional imports"
 msgid "允许在命令行中传递额外参数"
 msgstr "Allows passing extra arguments in the command line"
 
-msgid "设置 LLaMA-Factory 的日志级别(\"DEBUG\",\"INFO\",\"WARN\")"
-msgstr "Sets the log level of LLaMA-Factory (\"DEBUG\", \"INFO\", \"WARN\")"
+msgid "设置 LlamaFactory 的日志级别(\"DEBUG\",\"INFO\",\"WARN\")"
+msgstr "Sets the log level of LlamaFactory (\"DEBUG\", \"INFO\", \"WARN\")"
 
 msgid "优先使用 ModelScope 下载模型/数据集或使用缓存路径中的模型/数据集"
 msgstr "Prioritizes using ModelScope to download models/datasets or uses them from the cache path"

--- a/docs/locales/en/LC_MESSAGES/advanced/best_practice/gpt-oss.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/best_practice/gpt-oss.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -23,8 +23,8 @@ msgid "3步实现 GPT-OSS 的 LoRA 微调"
 msgstr "3 Steps to LoRA Fine-tuning for GPT-OSS"
 
 #: ../../source/finetune_best_practices.rst:8
-msgid "1. 安装 LLaMA-Factory 和 transformers"
-msgstr "1. Install LLaMA-Factory and transformers"
+msgid "1. 安装 LlamaFactory 和 transformers"
+msgstr "1. Install LlamaFactory and transformers"
 
 #: ../../source/finetune_best_practices.rst:15
 msgid "2. 在单张 GPU 上训练 GPT-OSS（要求显存 > 44 GB, 支持多 GPU）"

--- a/docs/locales/en/LC_MESSAGES/advanced/best_practice/index.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/best_practice/index.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #

--- a/docs/locales/en/LC_MESSAGES/advanced/distributed.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/distributed.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -24,9 +24,9 @@ msgstr "Distributed Training"
 
 #: ../../source/advanced/distributed.rst:5 37afc57f02104e8e90049be26b758138
 msgid ""
-"LLaMA-Factory 支持单机多卡和多机多卡分布式训练。同时也支持 :ref:`DDP <NativeDDP>`、:ref:`DeepSpeed <deepspeed_ref>` 和 :ref:`FSDP <fsdp_ref>` 三种分布式引擎。"
+"LlamaFactory 支持单机多卡和多机多卡分布式训练。同时也支持 :ref:`DDP <NativeDDP>`、:ref:`DeepSpeed <deepspeed_ref>` 和 :ref:`FSDP <fsdp_ref>` 三种分布式引擎。"
 msgstr ""
-"LLaMA-Factory supports single-node multi-card and Multi-node Multi-card distributed training. It also supports three distributed engines: :ref:`DDP <NativeDDP>`, "
+"LlamaFactory supports single-node multi-card and Multi-node Multi-card distributed training. It also supports three distributed engines: :ref:`DDP <NativeDDP>`, "
 ":ref:`DeepSpeed <deepspeed_ref>`, and :ref:`FSDP <fsdp_ref>`."
 
 #: ../../source/advanced/distributed.rst:8 6f41c1bfbe2f4d8797e9fcfaa9f71419
@@ -287,8 +287,8 @@ msgstr ""
 "ZeRO-1 and ensure ``offload_param=none``."
 
 #: ../../source/advanced/distributed.rst:277 833679101b7349ffa7a04e48e8cb61ae
-msgid "LLaMA-Factory提供了使用不同阶段的 DeepSpeed 配置文件的示例。包括："
-msgstr "LLaMA-Factory provides examples of DeepSpeed configuration files using different stages. Including:"
+msgid "LlamaFactory提供了使用不同阶段的 DeepSpeed 配置文件的示例。包括："
+msgstr "LlamaFactory provides examples of DeepSpeed configuration files using different stages. Including:"
 
 #: ../../source/advanced/distributed.rst:279 2f07eff88b6f42fabc3abaaf00949917
 msgid ":ref:`ZeRO-0` (不开启)"
@@ -356,8 +356,8 @@ msgid "``--include localhost:1`` 表示只是用本节点的gpu1。"
 msgstr "``--include localhost:1`` means only use gpu1 on this node."
 
 #: ../../source/advanced/distributed.rst:363 41a8feca563246f0b38f0313623bb645
-msgid "LLaMA-Factory 支持使用 DeepSpeed 的多机多卡训练，您可以通过以下命令启动："
-msgstr "LLaMA-Factory supports multi-node multi-card training using DeepSpeed. You can start it with the following command:"
+msgid "LlamaFactory 支持使用 DeepSpeed 的多机多卡训练，您可以通过以下命令启动："
+msgstr "LlamaFactory supports multi-node multi-card training using DeepSpeed. You can start it with the following command:"
 
 #: ../../source/advanced/distributed.rst:374 474171b5bcda4c838cab1098e8a6af78
 msgid "您也可以使用 ``deepspeed`` 指令来启动多机多卡训练。"
@@ -508,11 +508,11 @@ msgstr ""
 #: ../../source/advanced/distributed.rst:613 a930d6492c1b4d02bc7c0d47957e48ad
 msgid ""
 "PyTorch 的全切片数据并行技术 `FSDP <https://pytorch.org/docs/stable/fsdp.html>`_ "
-"（Fully Sharded Data Parallel）能让我们处理更多更大的模型。LLaMA-Factory支持使用 FSDP "
+"（Fully Sharded Data Parallel）能让我们处理更多更大的模型。LlamaFactory支持使用 FSDP "
 "引擎进行分布式训练。"
 msgstr ""
 "PyTorch's Fully Sharded Data Parallel technique `FSDP <https://pytorch.org/docs/stable/fsdp.html>`_ "
-"allows us to handle more and larger models. LLaMA-Factory supports distributed training using the FSDP "
+"allows us to handle more and larger models. LlamaFactory supports distributed training using the FSDP "
 "engine."
 
 #: ../../source/advanced/distributed.rst:615 2162ed257620493682b2343fb7d45bdd
@@ -612,7 +612,7 @@ msgstr "FSDP2"
 
 #: ../../source/advanced/distributed.rst:768
 msgid "当前LLamafactory基于Accelerate集成使用FSDP2的分布式训练，与FSDP的差异主要在于参数配置的不同。您可以采用FSDP相同的方式运行单机多卡和多机多卡。我们也为您提供了通用的入参配置："
-msgstr "Currently, LLaMA-Factory uses FSDP2 for distributed training based on Accelerate integration. The main difference from FSDP lies in parameter configuration. You can run single-node multi-card and multi-node multi-card in the same way as FSDP. We also provide general input parameter configurations:"
+msgstr "Currently, LlamaFactory uses FSDP2 for distributed training based on Accelerate integration. The main difference from FSDP lies in parameter configuration. You can run single-node multi-card and multi-node multi-card in the same way as FSDP. We also provide general input parameter configurations:"
 
 #: ../../source/advanced/distributed.rst:796
 msgid "您可以通过以下命令快速拉起训练脚本："

--- a/docs/locales/en/LC_MESSAGES/advanced/extras.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/extras.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -20,7 +20,7 @@ msgstr ""
 
 msgid ""
 msgstr ""
-"Project-Id-Version: LLaMA Factory \n"
+"Project-Id-Version: LlamaFactory \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-03-05 01:10+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -44,11 +44,11 @@ msgstr "LLaMA Pro"
 #: ../../source/advanced/extras.rst:8 a1b665e091ba4f0ea6477621b560e2a4
 msgid ""
 "为了解决大语言模型的遗忘问题， LLaMA Pro 通过在原有模型上增加新模块以适应新的任务，使其在多个新任务上的表现均优于原始模型。 "
-"LLaMA-Factory 支持 LLaMA Pro 的使用。 您可以使用运行 ``expand.sh`` 将 ``Meta-Llama-3"
+"LlamaFactory 支持 LLaMA Pro 的使用。 您可以使用运行 ``expand.sh`` 将 ``Meta-Llama-3"
 "-8B-Instruct`` 扩展为 ``llama3-8b-instruct-pro``。"
 msgstr ""
 "To address the forgetting problem in large language models, LLaMA Pro adds new modules to the original model to adapt to new tasks, enabling it to perform better than the original model on multiple new tasks. "
-"LLaMA-Factory supports the use of LLaMA Pro. You can run ``expand.sh`` to expand ``Meta-Llama-3"
+"LlamaFactory supports the use of LLaMA Pro. You can run ``expand.sh`` to expand ``Meta-Llama-3"
 "-8B-Instruct`` to ``llama3-8b-instruct-pro``."
 
 #: ../../source/advanced/extras.rst:12 116528b1860a4e75af83bf813af8f34b

--- a/docs/locales/en/LC_MESSAGES/advanced/model_support.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/model_support.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -23,8 +23,8 @@ msgid "模型支持"
 msgstr "Model Support"
 
 #: model_support.rst
-msgid "LLaMA-Factory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多模态模型为例，详细介绍如何为新模型添加支持。对于多模态模型，我们需要完成两个主要任务："
-msgstr "LLaMA-Factory allows users to add support for custom models. We will take the LLaMA-4 multimodal model as an example to introduce how to add support for a new model. For multimodal models, we need to complete two main tasks:"
+msgid "LlamaFactory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多模态模型为例，详细介绍如何为新模型添加支持。对于多模态模型，我们需要完成两个主要任务："
+msgstr "LlamaFactory allows users to add support for custom models. We will take the LLaMA-4 multimodal model as an example to introduce how to add support for a new model. For multimodal models, we need to complete two main tasks:"
 
 #: model_support.rst
 msgid "注册模型的template"
@@ -121,8 +121,8 @@ msgid "多模态数据构建"
 msgstr "Multimodal Data Construction"
 
 #: model_support.rst
-msgid "对于多模态模型，我们参照原始模型在 LLaMA-Factory 中实现多模态数据的解析。"
-msgstr "For multimodal models, we refer to the original model to implement multimodal data parsing in LLaMA-Factory."
+msgid "对于多模态模型，我们参照原始模型在 LlamaFactory 中实现多模态数据的解析。"
+msgstr "For multimodal models, we refer to the original model to implement multimodal data parsing in LlamaFactory."
 
 #: model_support.rst
 msgid "我们可以在 ``src/llamafactory/data/mm_plugin.py`` 中实现 ``Llama4Plugin`` 类来解析多模态数据。"
@@ -133,17 +133,17 @@ msgid "``Llama4Plugin`` 类继承自 ``BasePlugin`` 类，并实现了 ``get_mm_
 msgstr "The ``Llama4Plugin`` class inherits from the ``BasePlugin`` class and implements the ``get_mm_inputs`` and ``process_messages`` methods to parse multimodal data."
 
 #: model_support.rst
-msgid "``get_mm_inputs`` 的作用是将图像、视频等多模态数据转化为模型可以接收的输入，如 ``pixel_values``。为实现 ``get_mm_inputs``，首先我们需要检查 llama4 的 processor 是否可以与 `已有实现 <https://github.com/hiyouga/LLaMA-Factory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264>`_ 兼容。模型官方仓库中的 `processing_llama4.py <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 表明 llama4 的 processor 返回数据包含字段 ``pixel_values``，这与 LLaMA-Factory 中的已有实现兼容。因此，我们只需要参照已有的 ``get_mm_inputs`` 方法实现即可。"
-msgstr "The function of ``get_mm_inputs`` is to convert multimodal data such as images and videos into inputs that the model can accept, such as ``pixel_values``. To implement ``get_mm_inputs``, we first need to check if the llama4 processor is compatible with the `existing implementation <https://github.com/hiyouga/LLaMA-Factory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264>`_. The `processing_llama4.py <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ in the official model repository indicates that the data returned by the llama4 processor contains the field ``pixel_values``, which is compatible with the existing implementation in LLaMA-Factory. Therefore, we only need to implement it by referring to the existing ``get_mm_inputs`` method."
+msgid "``get_mm_inputs`` 的作用是将图像、视频等多模态数据转化为模型可以接收的输入，如 ``pixel_values``。为实现 ``get_mm_inputs``，首先我们需要检查 llama4 的 processor 是否可以与 `已有实现 <https://github.com/hiyouga/LlamaFactory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264>`_ 兼容。模型官方仓库中的 `processing_llama4.py <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 表明 llama4 的 processor 返回数据包含字段 ``pixel_values``，这与 LlamaFactory 中的已有实现兼容。因此，我们只需要参照已有的 ``get_mm_inputs`` 方法实现即可。"
+msgstr "The function of ``get_mm_inputs`` is to convert multimodal data such as images and videos into inputs that the model can accept, such as ``pixel_values``. To implement ``get_mm_inputs``, we first need to check if the llama4 processor is compatible with the `existing implementation <https://github.com/hiyouga/LlamaFactory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264>`_. The `processing_llama4.py <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ in the official model repository indicates that the data returned by the llama4 processor contains the field ``pixel_values``, which is compatible with the existing implementation in LlamaFactory. Therefore, we only need to implement it by referring to the existing ``get_mm_inputs`` method."
 
 #: model_support.rst
-msgid "``process_messages`` 的作用是根据输入图片/视频的大小，数量等信息在 messages 中插入相应数量的占位符，以便模型可以正确解析多模态数据。 我们需要参考 `原仓库实现 <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 以及 LLaMA-Factory 中的规范返回 ``list[dict[str, str]]`` 类型的 messages。"
-msgstr "The function of ``process_messages`` is to insert a corresponding number of placeholders in the messages based on the size, quantity, etc., of the input images/videos so that the model can correctly parse the multimodal data. We need to refer to the `original repository implementation <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ and the specifications in LLaMA-Factory to return messages of type ``list[dict[str, str]]``."
+msgid "``process_messages`` 的作用是根据输入图片/视频的大小，数量等信息在 messages 中插入相应数量的占位符，以便模型可以正确解析多模态数据。 我们需要参考 `原仓库实现 <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 以及 LlamaFactory 中的规范返回 ``list[dict[str, str]]`` 类型的 messages。"
+msgstr "The function of ``process_messages`` is to insert a corresponding number of placeholders in the messages based on the size, quantity, etc., of the input images/videos so that the model can correctly parse the multimodal data. We need to refer to the `original repository implementation <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ and the specifications in LlamaFactory to return messages of type ``list[dict[str, str]]``."
 
 #: model_support.rst
 msgid "提供模型路径"
 msgstr "Provide Model Path"
 
 #: model_support.rst
-msgid "最后, 在 `src/llamafactory/extras/constants.py <https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/extras/constants.py>`_ 中提供模型的下载路径。例如："
-msgstr "Finally, provide the model download path in `src/llamafactory/extras/constants.py <https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/extras/constants.py>`_. For example:"
+msgid "最后, 在 `src/llamafactory/extras/constants.py <https://github.com/hiyouga/LlamaFactory/blob/main/src/llamafactory/extras/constants.py>`_ 中提供模型的下载路径。例如："
+msgstr "Finally, provide the model download path in `src/llamafactory/extras/constants.py <https://github.com/hiyouga/LlamaFactory/blob/main/src/llamafactory/extras/constants.py>`_. For example:"

--- a/docs/locales/en/LC_MESSAGES/advanced/monitor.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/monitor.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -24,11 +24,11 @@ msgstr "Monitors"
 
 #: ../../source/advanced/monitor.rst:4 84a533f055934d13a7ba576233a7b26d
 msgid ""
-"LLaMA-Factory 支持多种训练可视化工具，包括：:ref:`LlamaBoard <LlamaBoard>` 、 "
+"LlamaFactory 支持多种训练可视化工具，包括：:ref:`LlamaBoard <LlamaBoard>` 、 "
 ":ref:`SwanLab <SwanLab>`、:ref:`TensorBoard <TensorBoard>` 、 :ref:`Wandb "
 "<Wandb>` 、 :ref:`MLflow <MLflow>` 。"
 msgstr ""
-"LLaMA-Factory supports multiple training visualization tools, including: :ref:`LlamaBoard <LlamaBoard>`, "
+"LlamaFactory supports multiple training visualization tools, including: :ref:`LlamaBoard <LlamaBoard>`, "
 ":ref:`SwanLab <SwanLab>`, :ref:`TensorBoard <TensorBoard>`, :ref:`Wandb "
 "<Wandb>`, :ref:`MLflow <MLflow>`."
 

--- a/docs/locales/en/LC_MESSAGES/advanced/quantization.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/quantization.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #

--- a/docs/locales/en/LC_MESSAGES/advanced/trainers.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/trainers.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #

--- a/docs/locales/en/LC_MESSAGES/advanced/tuning_algorithms.po
+++ b/docs/locales/en/LC_MESSAGES/advanced/tuning_algorithms.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -24,11 +24,11 @@ msgstr "Tuning algorithms"
 
 #: ../../source/advanced/adapters.rst:6 dbdce8a639e94307af3ff627763ab812
 msgid ""
-"LLaMA-Factory 支持多种调优算法，包括： :ref:`Full Parameter Fine-tuning <full>` 、 "
+"LlamaFactory 支持多种调优算法，包括： :ref:`Full Parameter Fine-tuning <full>` 、 "
 ":ref:`Freeze <Freeze>` 、 :ref:`LoRA <LoRA>` 、 :ref:`Galore <Galore>` 、 "
 ":ref:`BAdam <BAdam>` 。"
 msgstr ""
-"LLaMA-Factory supports multiple fine-tuning algorithms, including: :ref:`Full Parameter Fine-tuning <full>`, "
+"LlamaFactory supports multiple fine-tuning algorithms, including: :ref:`Full Parameter Fine-tuning <full>`, "
 ":ref:`Freeze <Freeze>`, :ref:`LoRA <LoRA>`, :ref:`Galore <Galore>`, "
 ":ref:`BAdam <BAdam>`."
 

--- a/docs/locales/en/LC_MESSAGES/getting_started/data_preparation.po
+++ b/docs/locales/en/LC_MESSAGES/getting_started/data_preparation.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -23,8 +23,8 @@ msgid "数据处理"
 msgstr "Data Preparation"
 
 #: data_preparation.rst
-msgid "`dataset_info.json <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dataset_info.json/>`_ 包含了所有经过预处理的 **本地数据集** 以及 **在线数据集**。如果您希望使用自定义数据集，请 **务必** 在 ``dataset_info.json`` 文件中添加对数据集及其内容的定义。"
-msgstr "`dataset_info.json <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dataset_info.json/>`_ contains all pre-processed **local datasets** and **online datasets**. If you wish to use a custom dataset, you **must** add the definition of the dataset and its content to the ``dataset_info.json`` file."
+msgid "`dataset_info.json <https://github.com/hiyouga/LlamaFactory/blob/main/data/dataset_info.json/>`_ 包含了所有经过预处理的 **本地数据集** 以及 **在线数据集**。如果您希望使用自定义数据集，请 **务必** 在 ``dataset_info.json`` 文件中添加对数据集及其内容的定义。"
+msgstr "`dataset_info.json <https://github.com/hiyouga/LlamaFactory/blob/main/data/dataset_info.json/>`_ contains all pre-processed **local datasets** and **online datasets**. If you wish to use a custom dataset, you **must** add the definition of the dataset and its content to the ``dataset_info.json`` file."
 
 #: data_preparation.rst
 msgid "目前我们支持 :ref:`Alpaca<alpaca>` 格式和  :ref:`ShareGPT<Sharegpt>` 格式的数据集。"
@@ -63,8 +63,8 @@ msgid "指令监督微调数据集"
 msgstr "Supervised Fine-Tuning Datasets"
 
 #: data_preparation.rst
-msgid "**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/alpaca_zh_demo.json/>`__"
-msgstr "**Sample Dataset**: `SFT Sample Dataset <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/alpaca_zh_demo.json/>`__"
+msgid "**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/alpaca_zh_demo.json/>`__"
+msgstr "**Sample Dataset**: `SFT Sample Dataset <https://github.com/hiyouga/LlamaFactory/blob/main/data/alpaca_zh_demo.json/>`__"
 
 #: data_preparation.rst
 msgid "指令监督微调(Instruct Tuning)通过让模型学习详细的指令以及对应的回答来优化模型在特定指令下的表现。"
@@ -107,8 +107,8 @@ msgid "预训练数据集"
 msgstr "Pre-training Datasets"
 
 #: data_preparation.rst
-msgid "**样例数据集**： `预训练样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/c4_demo.json/>`_"
-msgstr "**Sample Dataset**: `Pre-training Sample Dataset <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/c4_demo.json/>`_"
+msgid "**样例数据集**： `预训练样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/c4_demo.json/>`_"
+msgstr "**Sample Dataset**: `Pre-training Sample Dataset <https://github.com/hiyouga/LlamaFactory/blob/main/data/c4_demo.json/>`_"
 
 #: data_preparation.rst
 msgid "大语言模型通过学习未被标记的文本进行预训练，从而学习语言的表征。通常，预训练数据集从互联网上获得，因为互联网上提供了大量的不同领域的文本信息，有助于提升模型的泛化能力。"
@@ -208,16 +208,16 @@ msgid ":ref:`OpenAI格式 <OpenAI格式>`"
 msgstr ":ref:`OpenAI Format <OpenAI格式>`"
 
 #: data_preparation.rst
-msgid "ShareGPT 格式中的 KTO 数据集（`样例 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/kto_en_demo.json/>`__）和多模态数据集（`样例 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/mllm_demo.json/>`__）与 Alpaca 格式的类似。"
-msgstr "KTO datasets (`sample <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/kto_en_demo.json/>`__) and multimodal datasets (`sample <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/mllm_demo.json/>`__) in ShareGPT format are similar to those in Alpaca format."
+msgid "ShareGPT 格式中的 KTO 数据集（`样例 <https://github.com/hiyouga/LlamaFactory/blob/main/data/kto_en_demo.json/>`__）和多模态数据集（`样例 <https://github.com/hiyouga/LlamaFactory/blob/main/data/mllm_demo.json/>`__）与 Alpaca 格式的类似。"
+msgstr "KTO datasets (`sample <https://github.com/hiyouga/LlamaFactory/blob/main/data/kto_en_demo.json/>`__) and multimodal datasets (`sample <https://github.com/hiyouga/LlamaFactory/blob/main/data/mllm_demo.json/>`__) in ShareGPT format are similar to those in Alpaca format."
 
 #: data_preparation.rst
 msgid "预训练数据集不支持 ShareGPT 格式。"
 msgstr "Pre-training datasets do not support ShareGPT format."
 
 #: data_preparation.rst
-msgid "**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/glaive_toolcall_zh_demo.json/>`__"
-msgstr "**Sample Dataset**: `SFT Sample Dataset <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/glaive_toolcall_zh_demo.json/>`__"
+msgid "**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/glaive_toolcall_zh_demo.json/>`__"
+msgstr "**Sample Dataset**: `SFT Sample Dataset <https://github.com/hiyouga/LlamaFactory/blob/main/data/glaive_toolcall_zh_demo.json/>`__"
 
 #: data_preparation.rst
 msgid "相比 ``alpaca`` 格式的数据集， ``sharegpt`` 格式支持 **更多** 的角色种类，例如 human、gpt、observation、function 等等。它们构成一个对象列表呈现在 ``conversations`` 列中。下面是 ``sharegpt`` 格式的一个例子："
@@ -228,8 +228,8 @@ msgid "注意其中 human 和 observation 必须出现在奇数位置，gpt 和 
 msgstr "Note that human and observation must appear at odd positions, while gpt and function must appear at even positions."
 
 #: data_preparation.rst
-msgid "**样例数据集**： `偏好数据样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dpo_zh_demo.json/>`_"
-msgstr "**Sample Dataset**: `Preference Sample Dataset <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dpo_zh_demo.json/>`_"
+msgid "**样例数据集**： `偏好数据样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/dpo_zh_demo.json/>`_"
+msgstr "**Sample Dataset**: `Preference Sample Dataset <https://github.com/hiyouga/LlamaFactory/blob/main/data/dpo_zh_demo.json/>`_"
 
 #: data_preparation.rst
 msgid "Sharegpt 格式的偏好数据集同样需要在 ``chosen`` 列中提供更优的消息，并在 ``rejected`` 列中提供更差的消息。下面是一个例子："

--- a/docs/locales/en/LC_MESSAGES/getting_started/eval.po
+++ b/docs/locales/en/LC_MESSAGES/getting_started/eval.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #

--- a/docs/locales/en/LC_MESSAGES/getting_started/inference.po
+++ b/docs/locales/en/LC_MESSAGES/getting_started/inference.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -25,8 +25,8 @@ msgstr "Inference"
 
 #: ../../source/getting_started/inference.rst:4
 #: d88fc64d59e7426fbed12621e54af563
-msgid "LLaMA-Factory 支持多种推理方式。"
-msgstr "LLaMA-Factory supports multiple inference methods."
+msgid "LlamaFactory 支持多种推理方式。"
+msgstr "LlamaFactory supports multiple inference methods."
 
 #: ../../source/getting_started/inference.rst:6
 #: ae16a772e0f64983bbbbe03cf22a28f6

--- a/docs/locales/en/LC_MESSAGES/getting_started/installation.po
+++ b/docs/locales/en/LC_MESSAGES/getting_started/installation.po
@@ -1,18 +1,19 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-03-05 01:10+0800\n"
+"Project-Id-Version: LlamaFactory\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-07 17:28+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language-Team: en <LL@li.org>\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -152,18 +153,18 @@ msgstr "Otherwise, check the system environment variables to ensure CUDA is corr
 
 #: ../../source/getting_started/installation.rst:95
 #: a1bb186efe7e4b1eb80d1f9c14c19266
-msgid "LLaMA-Factory 安装"
-msgstr "LLaMA-Factory Installation"
+msgid "LlamaFactory 安装"
+msgstr "LlamaFactory Installation"
 
 #: ../../source/getting_started/installation.rst:97
 #: 29ca2cbd15524915947729355e5cd09b
-msgid "在安装 LLaMA-Factory 之前，请确保您安装了下列依赖:"
-msgstr "Before installing LLaMA-Factory, please make sure you have installed the following dependencies:"
+msgid "在安装 LlamaFactory 之前，请确保您安装了下列依赖:"
+msgstr "Before installing LlamaFactory, please make sure you have installed the following dependencies:"
 
 #: ../../source/getting_started/installation.rst:99
 #: 019b4f629f0a42f684b10aea2112f263
-msgid "运行以下指令以安装 LLaMA-Factory 及其依赖:"
-msgstr "Run the following commands to install LLaMA-Factory and its dependencies:"
+msgid "运行以下指令以安装 LlamaFactory 及其依赖:"
+msgstr "Run the following commands to install LlamaFactory and its dependencies:"
 
 #: ../../source/getting_started/installation.rst:107
 #: 57f730650c70479badf55b3961a4dbd7
@@ -172,8 +173,8 @@ msgstr "If there are environment conflicts, try to resolve them using ``pip inst
 
 #: ../../source/getting_started/installation.rst:110
 #: 0bfc3771dce04b9eb53c73ceb8029930
-msgid "LLaMA-Factory 校验"
-msgstr "LLaMA-Factory Verification"
+msgid "LlamaFactory 校验"
+msgstr "LlamaFactory Verification"
 
 #: ../../source/getting_started/installation.rst:112
 #: ad775080fd04493cbfcf7092facef952
@@ -187,8 +188,8 @@ msgstr "If you can successfully see an interface similar to the one below, it me
 
 #: ../../source/getting_started/installation.rst:119
 #: 3a4c2c7fbcc6408c917a9064c4e16004
-msgid "LLaMA-Factory 高级选项"
-msgstr "LLaMA-Factory Advanced Options"
+msgid "LlamaFactory 高级选项"
+msgstr "LlamaFactory Advanced Options"
 
 #: ../../source/getting_started/installation.rst:126
 #: 9bf2ddb733b1437196d45a3aef5879ce
@@ -252,8 +253,8 @@ msgstr "Open-source deep learning framework PyTorch, widely used in machine lear
 
 #: ../../source/getting_started/installation.rst:153
 #: 638b480dba4a45b4803017fbf8b77750
-msgid "torch-npu"
-msgstr "torch-npu"
+msgid "TorchNPU"
+msgstr "TorchNPU"
 
 #: ../../source/getting_started/installation.rst:154
 #: ea6a951141c44881b735b8185d7e87f2
@@ -396,6 +397,5 @@ msgstr "dev"
 
 #: ../../source/getting_started/installation.rst:184
 #: 820c7cccfc5e4f08b1ff2e844b205d26
-msgid "用于 LLaMA Factory 开发维护。"
-msgstr "For LLaMA Factory development and maintenance."
-
+msgid "用于 LlamaFactory 开发维护。"
+msgstr "For LlamaFactory development and maintenance."

--- a/docs/locales/en/LC_MESSAGES/getting_started/merge_lora.po
+++ b/docs/locales/en/LC_MESSAGES/getting_started/merge_lora.po
@@ -1,11 +1,11 @@
-# English translations for LLaMA Factory.
+# English translations for LlamaFactory.
 # Copyright (C) 2026 ORGANIZATION
-# This file is distributed under the same license as the LLaMA Factory project.
+# This file is distributed under the same license as the LlamaFactory project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: LLaMA Factory VERSION\n"
+"Project-Id-Version: LlamaFactory VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2026-04-29 14:59+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -49,8 +49,8 @@ msgid "Checkpoint 保存策略"
 msgstr "Checkpoint Saving Strategy"
 
 #: ../../source/getting_started/merge_lora.rst:21 3c21f993eadb46b39d7e23ee6cb71eeb
-msgid "LLaMA-Factory 的 checkpoint 保存行为主要由以下参数控制："
-msgstr "Checkpoint saving behavior in LLaMA-Factory is mainly controlled by the following parameters:"
+msgid "LlamaFactory 的 checkpoint 保存行为主要由以下参数控制："
+msgstr "Checkpoint saving behavior in LlamaFactory is mainly controlled by the following parameters:"
 
 #: ../../source/getting_started/merge_lora.rst:23 2ea4ede6d6b446288a4aa85c2894f622
 msgid "``save_strategy``：控制保存策略，通常可设为 ``steps``、``epoch`` 或 ``no``。"
@@ -185,10 +185,10 @@ msgstr ""
 "speed."
 
 #: ../../source/getting_started/merge_lora.rst:113 c4a1513d0e604481821d1719ed791df0
-msgid "量化（Quantization）通过数据精度压缩有效地减少了显存使用并加速推理。LLaMA-Factory 支持多种量化方法，包括:"
+msgid "量化（Quantization）通过数据精度压缩有效地减少了显存使用并加速推理。LlamaFactory 支持多种量化方法，包括:"
 msgstr ""
 "Quantization effectively reduces memory usage and speeds up inference by compressing numerical "
-"precision. LLaMA-Factory supports multiple quantization methods, including:"
+"precision. LlamaFactory supports multiple quantization methods, including:"
 
 #: ../../source/getting_started/merge_lora.rst:115 adcc21df7f934521a6c2fa3b5dd3b745
 msgid "AQLM"

--- a/docs/locales/en/LC_MESSAGES/getting_started/sft.po
+++ b/docs/locales/en/LC_MESSAGES/getting_started/sft.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -35,8 +35,8 @@ msgid "也可以通过追加参数更新 yaml 文件中的参数:"
 msgstr "You can also update the YAML parameters by appending them:"
 
 #: ../../source/getting_started/train.rst:18
-msgid "LLaMA-Factory 默认使用所有可见的计算设备。根据需求可通过 ``CUDA_VISIBLE_DEVICES`` 或 ``ASCEND_RT_VISIBLE_DEVICES`` 指定计算设备。"
-msgstr "By default, LLaMA-Factory uses all visible computing devices. You can specify which devices to use via ``CUDA_VISIBLE_DEVICES`` or ``ASCEND_RT_VISIBLE_DEVICES`` if needed."
+msgid "LlamaFactory 默认使用所有可见的计算设备。根据需求可通过 ``CUDA_VISIBLE_DEVICES`` 或 ``ASCEND_RT_VISIBLE_DEVICES`` 指定计算设备。"
+msgstr "By default, LlamaFactory uses all visible computing devices. You can specify which devices to use via ``CUDA_VISIBLE_DEVICES`` or ``ASCEND_RT_VISIBLE_DEVICES`` if needed."
 
 #: ../../source/getting_started/sft.rst:19 9bb225e0f4024c1d836eadba17cfa492
 msgid ""

--- a/docs/locales/en/LC_MESSAGES/getting_started/webui.po
+++ b/docs/locales/en/LC_MESSAGES/getting_started/webui.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -24,10 +24,10 @@ msgstr "WebUI"
 
 #: ../../source/getting_started/webui.rst:4 5e1dd58e4664493ab89abe2d9b03370a
 msgid ""
-"LLaMA-Factory 支持通过 WebUI 零代码微调大语言模型。 在完成 :ref:`安装 <installation>` "
+"LlamaFactory 支持通过 WebUI 零代码微调大语言模型。 在完成 :ref:`安装 <installation>` "
 "后，您可以通过以下指令进入 WebUI:"
 msgstr ""
-"LLaMA-Factory supports zero-code fine-tuning of large language models through WebUI. After completing :ref:`installation <installation>`, "
+"LlamaFactory supports zero-code fine-tuning of large language models through WebUI. After completing :ref:`installation <installation>`, "
 "you can enter the WebUI with the following command:"
 
 #: ../../source/getting_started/webui.rst:11 b02c090728734be0bae90dd2d79ea769

--- a/docs/locales/en/LC_MESSAGES/index.po
+++ b/docs/locales/en/LC_MESSAGES/index.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
@@ -22,8 +22,8 @@ msgid "开始使用"
 msgstr "Getting Started"
 
 #: ../../source/index.rst:34
-msgid "常见问题 <https://github.com/hiyouga/LLaMA-Factory/issues/4614>"
-msgstr "FAQ <https://github.com/hiyouga/LLaMA-Factory/issues/4614>"
+msgid "常见问题 <https://github.com/hiyouga/LlamaFactory/issues/4614>"
+msgstr "FAQ <https://github.com/hiyouga/LlamaFactory/issues/4614>"
 
 #: ../../source/index.rst:34
 msgid "常见问题"
@@ -38,8 +38,8 @@ msgid "多设备后端"
 msgstr "Multi-device Backends"
 
 #: ../../source/index.rst:2 fd8ae0c59b1749b7a93b79608f4c5bd5
-msgid "Welcome to LLaMA Factory!"
-msgstr "Welcome to LLaMA Factory!"
+msgid "Welcome to LlamaFactory!"
+msgstr "Welcome to LlamaFactory!"
 
 #: ../../source/index.rst:4 7e0af92b0ba8464d8c04e1509b274c52
 msgid "logo"
@@ -47,11 +47,11 @@ msgstr "logo"
 
 #: ../../source/index.rst:10 b6505192106e439997a67939acf9e331
 msgid ""
-"LLaMA Factory 是一个简单易用且高效的大型语言模型（Large Language Model）训练与微调平台。通过 LLaMA "
-"Factory，可以在无需编写任何代码的前提下，在本地完成上百种预训练模型的微调，框架特性包括："
+"LlamaFactory 是一个简单易用且高效的大型语言模型（Large Language Model）训练与微调平台。通过 "
+"LlamaFactory，可以在无需编写任何代码的前提下，在本地完成上百种预训练模型的微调，框架特性包括："
 msgstr ""
-"LLaMA Factory is an easy-to-use and efficient platform for training and fine-tuning large language models. "
-"With LLaMA Factory, you can fine-tune hundreds of pre-trained models locally without writing any code. "
+"LlamaFactory is an easy-to-use and efficient platform for training and fine-tuning large language models. "
+"With LlamaFactory, you can fine-tune hundreds of pre-trained models locally without writing any code. "
 "Framework features include:"
 #: ../../source/index.rst:12 9f1d904997c747e29bfba74eaef2ac41
 msgid ""
@@ -98,4 +98,3 @@ msgstr "Experiment Monitors: LlamaBoard, TensorBoard, Wandb, MLflow, SwanLab etc
 #: ../../source/index.rst:21 a08a94d2a0dc451184589260713483a3
 msgid "Documentation"
 msgstr "Documentation"
-

--- a/docs/locales/en/LC_MESSAGES/multibackend/npu/index.po
+++ b/docs/locales/en/LC_MESSAGES/multibackend/npu/index.po
@@ -1,6 +1,6 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #

--- a/docs/locales/en/LC_MESSAGES/multibackend/npu/npu_installation.po
+++ b/docs/locales/en/LC_MESSAGES/multibackend/npu/npu_installation.po
@@ -1,64 +1,74 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) 2025, LlamaFactory team.
-# This file is distributed under the same license as the LLaMA Factory
+# This file is distributed under the same license as the LlamaFactory
 # package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: LLaMA Factory \\n"
-"Report-Msgid-Bugs-To: \\n"
-"POT-Creation-Date: 2025-03-05 01:10+0800\\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
-"Language: en\\n"
-"Language-Team: en <LL@li.org>\\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\\n"
-"MIME-Version: 1.0\\n"
-"Content-Type: text/plain; charset=utf-8\\n"
-"Content-Transfer-Encoding: 8bit\\n"
-"Generated-By: Babel 2.16.0\\n"
+"Project-Id-Version: LlamaFactory \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-07 18:08+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.16.0\n"
 
-#: ../../source/multibackend/npu/npu_installation.rst:1
+#: ../../source/multibackend/npu/npu_installation.rst:2
+#: a48f9328258c44249859dbf701af7d11
 msgid "NPU安装及配置"
 msgstr "NPU Installation"
 
 #: ../../source/multibackend/npu/npu_installation.rst:4
-msgid "本文档介绍 LLaMA-Factory 在华为昇腾 NPU 上的环境准备方式。当前主要面向 Atlas A2/A3 训练系列设备；开始安装前，请先确认硬件型号和操作系统兼容性，再根据部署方式选择后续步骤。"
-msgstr "This document describes how to prepare the LLaMA-Factory environment on Huawei Ascend NPUs. It currently focuses on Atlas A2/A3 training series devices. Before installation, confirm the hardware model and operating system compatibility, and then choose the appropriate deployment method."
+#: 6fc4388f03c04fcc84703d33cda5067c
+msgid "本文档介绍 LlamaFactory 在华为昇腾 NPU 上的环境准备方式。当前主要面向 Atlas A2/A3 训练系列设备；开始安装前，请先确认硬件型号和操作系统兼容性，再根据部署方式选择后续步骤。"
+msgstr "This document describes how to prepare the LlamaFactory environment on Huawei Ascend NPUs. It currently focuses on Atlas A2/A3 training series devices. Before installation, confirm the hardware model and operating system compatibility, and then choose the appropriate deployment method."
 
 #: ../../source/multibackend/npu/npu_installation.rst:7
+#: 042c3917233f4544a8fcfebb941d0375
 msgid "硬件配套和支持的操作系统"
 msgstr "Hardware Compatibility and Supported Operating Systems"
 
 #: ../../source/multibackend/npu/npu_installation.rst:9
+#: 341b6b9095f74d4eb30e2d7b1695a3ee
 msgid "**表 1**  产品硬件支持列表"
 msgstr "**Table 1**  Hardware Support List"
 
 #: ../../source/multibackend/npu/npu_installation.rst:17
+#: c7e04a45fa2748f9b0921cbe50eb13ac
 msgid "产品"
 msgstr "Product"
 
 #: ../../source/multibackend/npu/npu_installation.rst:18
+#: 6c34553dd19f41168c3f039cf984e292
 msgid "是否支持"
 msgstr "Supported"
 
 #: ../../source/multibackend/npu/npu_installation.rst:19
+#: 3ae18d680f5949b68f51ab31ee9b09a8
 msgid "Ascend 950 系列产品"
 msgstr "Ascend 950 Series Products"
 
 #: ../../source/multibackend/npu/npu_installation.rst:20
 #: ../../source/multibackend/npu/npu_installation.rst:22
 #: ../../source/multibackend/npu/npu_installation.rst:26
+#: db58081649ed42a696a28349ab4dd9ff 92d38c8201d24657bd0bb495c281c44c
+#: 2d3b3a7101304dfaa91a031f1bfd19c4
 msgid "√"
 msgstr "√"
 
 #: ../../source/multibackend/npu/npu_installation.rst:21
+#: 65fa16b2552a4354bb6f38f1ed0623f8
 msgid "Atlas A3 训练系列产品"
 msgstr "Atlas A3 Training Series Products"
 
 #: ../../source/multibackend/npu/npu_installation.rst:23
+#: ab3c65bc396c4538a45712606f996583
 msgid "Atlas A3 推理系列产品"
 msgstr "Atlas A3 Inference Series Products"
 
@@ -67,393 +77,696 @@ msgstr "Atlas A3 Inference Series Products"
 #: ../../source/multibackend/npu/npu_installation.rst:30
 #: ../../source/multibackend/npu/npu_installation.rst:32
 #: ../../source/multibackend/npu/npu_installation.rst:34
+#: d699a7e0bbda46459302d8b7963f4af9 c594e7328d4c4d0590741bdd9afaf4d8
+#: 34781f0b64ce49938cbfbff0477a39dc 05fb830667cb4cbe97f5be848a202273
+#: eb0896e17b2d4c90941f6fcbc219eecb
 msgid "x"
 msgstr "x"
 
 #: ../../source/multibackend/npu/npu_installation.rst:25
+#: 034bae240b2b4b60826aa0ea69ddc0ae
 msgid "Atlas A2 训练系列产品"
 msgstr "Atlas A2 Training Series Products"
 
 #: ../../source/multibackend/npu/npu_installation.rst:27
+#: 9e0e80db57954a54bebc0442bc8ea4e6
 msgid "Atlas A2 推理系列产品"
 msgstr "Atlas A2 Inference Series Products"
 
 #: ../../source/multibackend/npu/npu_installation.rst:29
+#: 3da11b6252824714a6789ba695160c70
 msgid "Atlas 200I/500 A2 推理产品"
 msgstr "Atlas 200I/500 A2 Inference Products"
 
 #: ../../source/multibackend/npu/npu_installation.rst:31
+#: e767ae1bc929437ebcf5b003d5733265
 msgid "Atlas 推理系列产品"
 msgstr "Atlas Inference Series Products"
 
 #: ../../source/multibackend/npu/npu_installation.rst:33
+#: ced7d6ac2bd14787b142e49625537389
 msgid "Atlas 训练系列产品"
 msgstr "Atlas Training Series Products"
 
-#: ../../source/multibackend/npu/npu_installation.rst:36
+#: ../../source/multibackend/npu/npu_installation.rst:38
+#: 7fb21386a1664d118ba2d2caed049bb1
 msgid "本节表格中“√”代表支持，“x”代表不支持。"
 msgstr "In this table, “√” indicates supported and “x” indicates not supported."
 
-#: ../../source/multibackend/npu/npu_installation.rst:38
+#: ../../source/multibackend/npu/npu_installation.rst:40
+#: a9599d0e11fa4225939dfcc8dcc93c8e
 msgid "各硬件产品对应物理机部署场景支持的操作系统请参考 `兼容性查询助手 <https://www.hiascend.com/hardware/compatibility>`_。"
 msgstr "For operating systems supported by each hardware product in physical-machine deployment scenarios, see the `Compatibility Query Assistant <https://www.hiascend.com/hardware/compatibility>`_."
 
-#: ../../source/multibackend/npu/npu_installation.rst:39
+#: ../../source/multibackend/npu/npu_installation.rst:41
+#: 543bec5e73e7418485ea31b43822965c
 msgid "各硬件产品对应虚拟机及容器部署场景支持的操作系统请参考《CANN 软件安装》的“`操作系统兼容性说明 <https://www.hiascend.com/document/detail/zh/canncommercial/900/softwareinst/instg/instg_0101.html?OS=openEuler&InstallType=netyum>`__”章节（商用版）或“`操作系统兼容性说明 <https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0101.html?OS=openEuler&InstallType=netyum>`__”章节（社区版）。"
 msgstr "For operating systems supported by each hardware product in VM and container deployment scenarios, see the “`Operating System Compatibility Description <https://www.hiascend.com/document/detail/zh/canncommercial/900/softwareinst/instg/instg_0101.html?OS=openEuler&InstallType=netyum>`__” section in CANN Software Installation (commercial edition) or the “`Operating System Compatibility Description <https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/900/softwareinst/instg/instg_0101.html?OS=openEuler&InstallType=netyum>`__” section (community edition)."
 
-#: ../../source/multibackend/npu/npu_installation.rst:41
+#: ../../source/multibackend/npu/npu_installation.rst:43
+#: 8fbb77d090514eaeaa25eb0d5638f400
 msgid "确认硬件和操作系统满足上述要求后，可以选择以下三种方式之一进行环境配置及使用："
 msgstr "After confirming that the hardware and operating system meet the preceding requirements, choose one of the following three methods for environment setup and usage:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:43
+#: ../../source/multibackend/npu/npu_installation.rst:45
+#: d557d80cbb9d4e61b22d0115c685a929
 msgid ":ref:`install_form_pip`"
 msgstr ":ref:`install_form_pip`"
 
-#: ../../source/multibackend/npu/npu_installation.rst:44
+#: ../../source/multibackend/npu/npu_installation.rst:46
+#: 29748325e3c240988140e0b034a6d782
 msgid ":ref:`use_form_docker`"
 msgstr ":ref:`use_form_docker`"
 
-#: ../../source/multibackend/npu/npu_installation.rst:45
+#: ../../source/multibackend/npu/npu_installation.rst:47
+#: e1dcd376e8cd41228fd90cb7f391cfee
 msgid ":ref:`install_form_docker`"
 msgstr ":ref:`install_form_docker`"
 
-#: ../../source/multibackend/npu/npu_installation.rst:49
+#: ../../source/multibackend/npu/npu_installation.rst:51
+#: bd3605282cf14d5e9740c72ecb32bb90
 msgid "核心依赖说明"
 msgstr "Core Dependencies"
 
-#: ../../source/multibackend/npu/npu_installation.rst:14
+#: ../../source/multibackend/npu/npu_installation.rst:53
+#: 0f501b6269f84587a2cce4047c9c9061
 msgid "所有安装方式均依赖以下组件："
 msgstr "All installation methods depend on the following components:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:16
+#: ../../source/multibackend/npu/npu_installation.rst:55
+#: 3cbf2fceea4d40379580235a75117f0a
 msgid "**HDK**：固件及驱动"
 msgstr "**HDK**: Firmware and drivers"
 
-#: ../../source/multibackend/npu/npu_installation.rst:17
+#: ../../source/multibackend/npu/npu_installation.rst:56
+#: d1dd70b1a2b140d2ab441669739cebe5
 msgid "**CANN**：异构计算架构"
 msgstr "**CANN**: Heterogeneous Computing Architecture"
 
-#: ../../source/multibackend/npu/npu_installation.rst:18
-msgid "**torch_npu**：PyTorch 的昇腾适配插件"
-msgstr "**torch_npu**: Ascend adaptation plugin for PyTorch"
+#: ../../source/multibackend/npu/npu_installation.rst:57
+#: bdca6ff8277f4519aceceb3da12e9db9
+msgid "**TorchNPU**：PyTorch 的昇腾适配插件"
+msgstr "**TorchNPU**: Ascend adaptation plugin for PyTorch"
 
-#: ../../source/multibackend/npu/npu_installation.rst:20
+#: ../../source/multibackend/npu/npu_installation.rst:59
+#: c64fd758505b47758a4d2fa1d039921a
 msgid "根据安装方式不同，所需操作有所区别："
 msgstr "Required steps vary depending on the installation method:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:22
-msgid "**手动安装**：需手动安装 HDK、CANN 和 torch_npu。"
-msgstr "**Manual installation**: Manually install HDK, CANN, and torch_npu."
+#: ../../source/multibackend/npu/npu_installation.rst:61
+#: d78f8953344c40569bb3278b5738ff21
+msgid "**手动安装**：需手动安装 HDK、CANN 和 TorchNPU。"
+msgstr "**Manual installation**: Manually install HDK, CANN, and TorchNPU."
 
-#: ../../source/multibackend/npu/npu_installation.rst:23
-msgid "**Docker 镜像/构建**：宿主机仅需安装 HDK (驱动/固件)，CANN 和 torch_npu 已集成在镜像中。"
-msgstr "**Docker image/build**: The host only needs to install HDK (driver/firmware). CANN and torch_npu are integrated in the image."
+#: ../../source/multibackend/npu/npu_installation.rst:62
+#: 45c49f314827416d9ae5e67ceced079a
+msgid "**Docker 镜像/构建**：宿主机仅需安装 HDK (驱动/固件)，CANN 和 TorchNPU 已集成在镜像中。"
+msgstr "**Docker image/build**: The host only needs to install HDK (driver/firmware). CANN and TorchNPU are integrated in the image."
 
-#: ../../source/multibackend/npu/npu_installation.rst:28
+#: ../../source/multibackend/npu/npu_installation.rst:68
+#: e181cd8ce4304163b558287e360ccf9f
 msgid "方式一：手动安装环境"
 msgstr "Method 1: Manual Environment Installation"
 
-#: ../../source/multibackend/npu/npu_installation.rst:31
-msgid "本方式需要您手动安装 HDK、CANN 和 torch_npu。"
-msgstr "This method requires you to manually install HDK, CANN, and torch_npu."
+#: ../../source/multibackend/npu/npu_installation.rst:70
+#: a310967860bd4ec28af860d3bbdc3830
+msgid "本方式需要您手动安装 HDK、CANN 和 TorchNPU。"
+msgstr "This method requires you to manually install HDK, CANN, and TorchNPU."
 
-#: ../../source/multibackend/npu/npu_installation.rst:34
+#: ../../source/multibackend/npu/npu_installation.rst:74
+#: a40f090b4c7842f6871937684d7ae17f
 msgid "1. 版本及下载链接"
 msgstr "1. Versions and Download Links"
 
-#: ../../source/multibackend/npu/npu_installation.rst:37
+#: ../../source/multibackend/npu/npu_installation.rst:76
+#: e0397ecdcda843ca8d8d9dc5927c60a2
 msgid "本文档列举了最新的依赖版本及下载链接，请根据设备型号选择："
 msgstr "This document lists the latest dependency versions and download links. Please choose according to your device model:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:44
+#: ../../source/multibackend/npu/npu_installation.rst:83
+#: cec569a4548644b08f1ba49a7c1aa03c
 msgid "设备"
 msgstr "Device"
 
-#: ../../source/multibackend/npu/npu_installation.rst:45
+#: ../../source/multibackend/npu/npu_installation.rst:84
+#: 5398ac8908b94d3dbef40c6742a9b9b9
 msgid "依赖"
 msgstr "Dependency"
 
-#: ../../source/multibackend/npu/npu_installation.rst:46
+#: ../../source/multibackend/npu/npu_installation.rst:85
+#: 19830042fe4e4399be55d3a85a96eb6b
 msgid "链接"
 msgstr "Link"
 
-#: ../../source/multibackend/npu/npu_installation.rst:72
+#: ../../source/multibackend/npu/npu_installation.rst:86
+#: ../../source/multibackend/npu/npu_installation.rst:291
+#: ../../source/multibackend/npu/npu_installation.rst:297
+#: ../../source/multibackend/npu/npu_installation.rst:426
+#: ../../source/multibackend/npu/npu_installation.rst:432
+#: 141559cbe893407aa9ac8fa06730c78e a5035a382db04e819de5efcf9624556b
+#: ac2480e2ce3542919843a91e0a178c62 2ddbfb6416174efeb3e72537f347d266
+#: b06c1d3e7e0a411fac9b555fcc8232aa
+msgid "A3"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:87
+#: ../../source/multibackend/npu/npu_installation.rst:96
+#: 8d8d850b860e43f4853c6f7ff0a7d408 ed6d88afd6de4a9eb4b2030c43a52a21
+msgid "HDK"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:88
+#: fbf19d8df5a142d388aeef99ec36a70b
+msgid "https://www.hiascend.com/hardware/firmware-drivers?ids=d803%2C89dda9ba9de741349efa03687a487678%2C16%2CAArch64%2Conline_Yum"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:90
+#: ../../source/multibackend/npu/npu_installation.rst:99
+#: b551f98d835e444c8edab9d8cc672888 303a6b75f0d14b1d8e75ffa268f35df5
+msgid "CANN"
+msgstr "CANN"
+
+#: ../../source/multibackend/npu/npu_installation.rst:91
+#: ../../source/multibackend/npu/npu_installation.rst:100
+#: 4b828891df134d229f46fb5f7ee68349 2b8d6a0f76ca4cf3802a3fd852777517
+msgid "https://www.hiascend.com/developer/download/community/result?module=cann&cann=9.1.0"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:93
+#: ../../source/multibackend/npu/npu_installation.rst:102
+#: 47afda69827142178bc33aabc6feb217 3b894a2346e14587ab79c9e586680736
+msgid "TorchNPU"
+msgstr "TorchNPU"
+
+#: ../../source/multibackend/npu/npu_installation.rst:94
+#: ../../source/multibackend/npu/npu_installation.rst:103
+#: 73f6693e67e6487d83a885c6e9cb3b2c 251540913c5a4f488aad47ac896e4788
+msgid "2.10.0.post2"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:95
+#: ../../source/multibackend/npu/npu_installation.rst:288
+#: ../../source/multibackend/npu/npu_installation.rst:294
+#: ../../source/multibackend/npu/npu_installation.rst:423
+#: ../../source/multibackend/npu/npu_installation.rst:429
+#: 2588115108a5410c80935d1b33f8109c 24c88f130c3a48a38e4a6a3142c459b8
+#: fad290d10cfd4832ac7d05748a35c41d a2921c0bd13c4e88919acf2077b90591
+#: df4a7b5cc49848769556ad0b4dcf7807
+msgid "A2"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:97
+#: 14795f421c544c06b8a2d6c1e545a748
+msgid "https://www.hiascend.com/hardware/firmware-drivers?ids=d802%2C26958bcc909e4cd48fa56d4c4a43ebec%2C17%2CAArch64%2Conline_Yum"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:106
+#: 6b272ae2e03a4dc2876efb30b8171823
 msgid "2. 驱动及固件"
 msgstr "2. Drivers and Firmware"
 
-#: ../../source/multibackend/npu/npu_installation.rst:75
+#: ../../source/multibackend/npu/npu_installation.rst:108
+#: 42e94bda67f948de8c908f93330bc865
 msgid "请根据实际情况选择 ``.run`` 或 ``.deb`` 的 HDK 安装包，并请注意安装包对 ``aarch64`` 和 ``x86`` 做了区分。"
 msgstr "Choose the HDK installation package in ``.run`` or ``.deb`` format as appropriate, noting that packages are differentiated for ``aarch64`` and ``x86``."
 
-#: ../../source/multibackend/npu/npu_installation.rst:77
+#: ../../source/multibackend/npu/npu_installation.rst:110
+#: 923408c49a124e13af13b2be0ab4ebe4
 msgid "以下以 A2 系列为例。A3 系列包 ``firmware`` 和 ``driver`` 包名有所变化，可以根据链接内实际情况选择。"
 msgstr "The following uses the A2 series as an example. For the A3 series, the ``firmware`` and ``driver`` package names differ; choose based on the linked page."
 
-#: ../../source/multibackend/npu/npu_installation.rst:79
+#: ../../source/multibackend/npu/npu_installation.rst:112
+#: a3fe401180f44789bd1f444e91ffdc2d
 msgid "A3 内部包名类似于 ``Atlas-A3-hdk-npu-driver_25.0.rc1.3_linux-aarch64.run`` 和 ``Atlas-A3-hdk-npu-firmware_7.7.0.3.228.run``，实际安装方式没有变化。"
 msgstr "A3 internal package names are similar to ``Atlas-A3-hdk-npu-driver_25.0.rc1.3_linux-aarch64.run`` and ``Atlas-A3-hdk-npu-firmware_7.7.0.3.228.run``. The installation method does not change."
 
-#: ../../source/multibackend/npu/npu_installation.rst:81
+#: ../../source/multibackend/npu/npu_installation.rst:114
+#: 4487d53a92ca4387a1f4bca219cac366
 msgid "上传安装包，以 root 用户登录，将驱动和固件包上传至服务器（如 ``/home``）。"
 msgstr "Upload installation packages, log in as root and upload the driver and firmware packages to the server (e.g., ``/home``)."
 
-#: ../../source/multibackend/npu/npu_installation.rst:84
+#: ../../source/multibackend/npu/npu_installation.rst:116
+#: 30270e950f9446c29f44b0c30e5cf556
 msgid "增加执行权限，进入安装包目录，执行以下命令。"
 msgstr "Add execution permissions, enter the package directory and execute the following commands."
 
-#: ../../source/multibackend/npu/npu_installation.rst:92
+#: ../../source/multibackend/npu/npu_installation.rst:123
+#: a19ff5521ad148febd07632c3622b71f
 msgid "安装驱动与固件，默认安装路径为 ``/usr/local/Ascend``。"
 msgstr "Install drivers and firmware, The default installation path is ``/usr/local/Ascend``."
 
-#: ../../source/multibackend/npu/npu_installation.rst:95
+#: ../../source/multibackend/npu/npu_installation.rst:125
+#: a35d756d52314a158599eb44c29e5d5d
 msgid "**安装驱动**："
 msgstr "**Install driver**:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:101
+#: ../../source/multibackend/npu/npu_installation.rst:131
+#: 9d841b0ecf0a4dd18a755e634dd89aa9
 msgid "出现 ``Driver package installed successfully!`` 表示成功。"
 msgstr "If ``Driver package installed successfully!`` appears, the installation succeeded."
 
-#: ../../source/multibackend/npu/npu_installation.rst:103
+#: ../../source/multibackend/npu/npu_installation.rst:133
+#: da56aa74106e44088363147a612c116e
 msgid "**安装固件**："
 msgstr "**Install firmware**:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:109
+#: ../../source/multibackend/npu/npu_installation.rst:139
+#: 256687b155d1417d80ced7987993650a
 msgid "出现 ``Firmware package installed successfully!`` 表示成功。"
 msgstr "If ``Firmware package installed successfully!`` appears, the installation succeeded."
 
-#: ../../source/multibackend/npu/npu_installation.rst:111
+#: ../../source/multibackend/npu/npu_installation.rst:143
+#: 7ae8435312e54a9084209d83fadc4c14
 msgid "若未创建默认用户 ``HwHiAiUser``，需在安装命令中指定用户和组： ``./Ascend-hdk-*.run --full --install-username=<username> --install-usergroup=<usergroup>``"
 msgstr "If the default user ``HwHiAiUser`` has not been created, specify the user and group in the installation command: ``./Ascend-hdk-*.run --full --install-username=<username> --install-usergroup=<usergroup>``"
 
-#: ../../source/multibackend/npu/npu_installation.rst:116
+#: ../../source/multibackend/npu/npu_installation.rst:145
+#: 65d3c0cc1c114b7887b7253dfff02aaf
 msgid "重启系统，根据提示决定是否重启。如需重启："
 msgstr "Decide whether to reboot according to prompts. To reboot:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:123
+#: ../../source/multibackend/npu/npu_installation.rst:151
+#: 9cc240b7582e462ba0c40d02b902b22a
 msgid "验证安装，执行以下命令查看驱动加载状态："
 msgstr "Verify installation. Run the following command to check driver load status:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:132
+#: ../../source/multibackend/npu/npu_installation.rst:160
+#: 2daf64c9870248628432c417c47b0bd9
 msgid "3. CANN"
 msgstr "3. CANN"
 
-#: ../../source/multibackend/npu/npu_installation.rst:135
+#: ../../source/multibackend/npu/npu_installation.rst:162
+#: 34dcc25d84044999ba4f52f8c03e345f
 msgid "请根据实际情况选择 ``.run`` 或 ``.deb`` 的 CANN 安装包，并请注意安装包对 ``aarch64`` 和 ``x86`` 做了区分。"
 msgstr "Choose the CANN installation package in ``.run`` or ``.deb`` format as appropriate, noting that packages are differentiated for ``aarch64`` and ``x86``."
 
-#: ../../source/multibackend/npu/npu_installation.rst:137
-msgid "以下以 A2 系列为例。A3 系列唯一区别是 ``ops`` 包名字有所变化，可以根据链接内实际情况选择。A3 内部包名类似于 ``Ascend-cann-A3-ops_9.0.0_linux-aarch64.run``，实际安装方式没有变化。"
-msgstr "The following uses the A2 series as an example. The only difference for the A3 series is the name of the ``ops`` package; choose according to the linked page. A3 internal package names are similar to ``Ascend-cann-A3-ops_9.0.0_linux-aarch64.run``. The installation method does not change."
+#: ../../source/multibackend/npu/npu_installation.rst:164
+#: bc7a453a758d40869c51ce8e924ea7b0
+msgid "以下以 A2 系列为例。A3 系列唯一区别是 ``ops`` 包名字有所变化，可以根据链接内实际情况选择。A3 内部包名类似于 ``Ascend-cann-A3-ops_<version>_linux-aarch64.run``，实际安装方式没有变化。"
+msgstr "The following uses the A2 series as an example. The only difference for the A3 series is the name of the ``ops`` package; choose according to the linked page. A3 package names are similar to ``Ascend-cann-A3-ops_<version>_linux-aarch64.run``. The installation method does not change."
 
-#: ../../source/multibackend/npu/npu_installation.rst:140
+#: ../../source/multibackend/npu/npu_installation.rst:168
+#: 273ab3d19c7247b0a75e3fc474b970b0
 msgid "(1) 安装 Toolkit 开发套件"
 msgstr "(1) Install Toolkit development kit"
 
-#: ../../source/multibackend/npu/npu_installation.rst:143
+#: ../../source/multibackend/npu/npu_installation.rst:170
+#: 4c86f2731733486ebab32c0261da48b7
 msgid "Toolkit 用于训练、推理及开发。"
 msgstr "Toolkit is used for training, inference, and development."
 
-#: ../../source/multibackend/npu/npu_installation.rst:145
+#: ../../source/multibackend/npu/npu_installation.rst:173
+#: bbaf4eaee9dd4fb0ab19578dfece7a3b
 msgid "请确保安装目录可用空间大于 10G。"
 msgstr "Ensure the installation directory has more than 10G of free space."
 
-
-#: ../../source/multibackend/npu/npu_installation.rst:150
+#: ../../source/multibackend/npu/npu_installation.rst:175
+#: 735fb4a1e9074a19869f840789d7695d
 msgid "**授权与安装**：以 root 用户安装，默认安装路径为 ``/usr/local/Ascend``；以普通用户安装，默认安装路径为 ``${HOME}/Ascend``。"
 msgstr "**Authorization and installation**: For root user: ``/usr/local/Ascend``; For normal user: ``${HOME}/Ascend``."
 
-#: ../../source/multibackend/npu/npu_installation.rst:158
+#: ../../source/multibackend/npu/npu_installation.rst:182
+#: 21787ac501eb496ebb3f40183aa5eeb0
 msgid "**配置环境变量**：以 root 用户为例，建议写入 ``~/.bashrc``。"
 msgstr "**Configure environment variables**: For root users, it is recommended to write to ``~/.bashrc``."
 
-#: ../../source/multibackend/npu/npu_installation.rst:166
+#: ../../source/multibackend/npu/npu_installation.rst:190
+#: 0b3b40dfc17d4dafb265e449343e3739
 msgid "(2) 安装 ops 算子包"
 msgstr "(2) Install ops operator package"
 
-#: ../../source/multibackend/npu/npu_installation.rst:169
+#: ../../source/multibackend/npu/npu_installation.rst:192
+#: 232137fdc3a244e2ae5a700164c6d527
 msgid "需在安装 Toolkit 后执行。如需安装静态库，请将 ``--install`` 改为 ``--devel``。"
 msgstr "Execute after installing Toolkit. To install static libraries, replace ``--install`` with ``--devel``."
 
-
-#: ../../source/multibackend/npu/npu_installation.rst:179
+#: ../../source/multibackend/npu/npu_installation.rst:201
+#: b14ea41850b54e759e350e5a19f39a1c
 msgid "(3) 安装 NNAL 神经网络加速库（可选）"
 msgstr "(3) Install NNAL neural network acceleration library (optional)"
 
-#: ../../source/multibackend/npu/npu_installation.rst:182
+#: ../../source/multibackend/npu/npu_installation.rst:203
+#: 6c49759e9098489d93ee0d5aaba717df
 msgid "包含 ATB 和 SiP 加速库。需在安装 Toolkit 后执行。"
 msgstr "Includes ATB and SiP acceleration libraries. Execute after installing Toolkit."
 
-#: ../../source/multibackend/npu/npu_installation.rst:188
+#: ../../source/multibackend/npu/npu_installation.rst:205
+#: bde3111941be4fdebf5137b74dd78e52
 msgid "**授权与安装**："
 msgstr "**Authorization and installation**:"
 
-
-#: ../../source/multibackend/npu/npu_installation.rst:188
+#: ../../source/multibackend/npu/npu_installation.rst:212
+#: 38da016591fb4295b861c990b7fa767d
 msgid "**配置环境变量**："
 msgstr "**Configure environment variables**:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:192
+#: ../../source/multibackend/npu/npu_installation.rst:214
+#: 38cb350e5d3a43b48050d008b5cfab65
 msgid "（二选一，不可同时配置）"
 msgstr "(Choose one of the two, do not configure both)"
 
-#: ../../source/multibackend/npu/npu_installation.rst:196
-msgid "# ATB"
-msgstr "# ATB"
+#: ../../source/multibackend/npu/npu_installation.rst:227
+#: db6aa22e67a04229961c89378a90e180
+msgid "4. TorchNPU"
+msgstr "4. TorchNPU"
 
-#: ../../source/multibackend/npu/npu_installation.rst:199
-msgid "# SiP"
-msgstr "# SiP"
+#: ../../source/multibackend/npu/npu_installation.rst:229
+#: b2a4a42cf1a641588fd3e67bf0d4fec9
+msgid "建议在安装 LlamaFactory 时一并安装 TorchNPU 插件，LlamaFactory 依赖内会持续更新稳定版本的 TorchNPU 插件。"
+msgstr "It is recommended to install the TorchNPU plugin together with LlamaFactory. LlamaFactory dependencies will continue to track stable TorchNPU releases."
 
-#: ../../source/multibackend/npu/npu_installation.rst:204
-msgid "4. torch-npu"
-msgstr "4. torch-npu"
+#: ../../source/multibackend/npu/npu_installation.rst:235
+#: 97f86aa88059411398e70219bbed5d5a
+msgid "当然您也可以手动下载后安装 TorchNPU 插件，例如："
+msgstr "You can also download and install the TorchNPU plugin manually, for example:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:207
-msgid "建议在安装 LLaMA-Factory 时一并安装 ``torch-npu`` 插件，LLaMA-Factory 依赖内会持续更新稳定版本的 ``torch-npu`` 插件。"
-msgstr "It is recommended to install the ``torch-npu`` plugin together when installing LLaMA-Factory. LLaMA-Factory dependencies will continuously update stable versions of the ``torch-npu`` plugin."
+#: ../../source/multibackend/npu/npu_installation.rst:241
+#: f18195cf3b3b43ffa817515aed2b640d
+msgid "安装 TorchNPU 插件需要注意："
+msgstr "Note the following when installing the TorchNPU plugin:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:213
-msgid "当然您也可以手动下载后安装 ``torch-npu`` 插件，例如："
-msgstr "You can also download and install the ``torch-npu`` plugin manually, for example:"
+#: ../../source/multibackend/npu/npu_installation.rst:243
+#: 88d5fe4de7fb4104a2a99ddd2102929e
+msgid "下载的 TorchNPU 会对支持的 Python 版本做区分，请根据实际环境情况选择对应安装包，``pip install torch_npu`` 时，也会一并安装对应版本的 ``torch``。"
+msgstr "TorchNPU packages are built for specific Python versions, so choose the package that matches your environment. Running ``pip install torch_npu`` also installs the corresponding version of ``torch``."
 
-#: ../../source/multibackend/npu/npu_installation.rst:219
-msgid "安装 ``torch-npu`` 插件需要注意："
-msgstr "Notes when installing the ``torch-npu`` plugin:"
+#: ../../source/multibackend/npu/npu_installation.rst:244
+#: 0e8596b2251f457ebfcc333fca160e54
+msgid "环境里安装的 TorchNPU 和 ``torch`` 版本需要对齐。例如 TorchNPU 版本为 ``2.10.0.post2`` 时，``torch`` 的版本也需要为 ``2.10.0``。有时依赖互斥，安装不用依赖的过程会导致 ``torch`` 版本被更新，从而导致报错。"
+msgstr "The TorchNPU and ``torch`` versions installed in the environment must be compatible. For example, TorchNPU ``2.10.0.post2`` requires ``torch`` ``2.10.0``. Dependency conflicts may sometimes cause ``torch`` to be upgraded during another package installation, resulting in errors."
 
-#: ../../source/multibackend/npu/npu_installation.rst:221
-msgid "下载的 ``torch_npu`` 会对支持的 Python 版本做区分，请根据实际环境情况选择对应安装包，``pip install torch_npu`` 时，也会一并安装对应版本的 ``torch``。"
-msgstr "The downloaded ``torch_npu`` distinguishes between supported Python versions. Choose the appropriate installation package for your environment. When running ``pip install torch_npu``, the corresponding version of ``torch`` will be installed together."
-
-#: ../../source/multibackend/npu/npu_installation.rst:222
-msgid "环境里安装的 ``torch-npu`` 和 ``torch`` 版本需要对齐。例如 ``torch-npu`` 版本为 ``2.7.1`` 时，``torch`` 的版本也需要为 ``2.7.1``。有时依赖互斥，安装不用依赖的过程会导致 ``torch`` 版本被更新，从而导致报错。"
-msgstr "The versions of ``torch-npu`` and ``torch`` installed in the environment must be aligned. For example, if ``torch-npu`` is version ``2.7.1``, then ``torch`` must also be version ``2.7.1``. Dependency conflicts may occasionally update ``torch`` during installation, leading to errors."
-
-#: ../../source/multibackend/npu/npu_installation.rst:224
+#: ../../source/multibackend/npu/npu_installation.rst:247
+#: 778be171098b40a0a3fdc766e3eb65c2
 msgid "5. 验证安装"
 msgstr "5. Verify Installation"
 
-#: ../../source/multibackend/npu/npu_installation.rst:227
+#: ../../source/multibackend/npu/npu_installation.rst:249
+#: c6f0f31f37784c849f3c64d26d1b6978
 msgid "执行以下 Python 脚本："
 msgstr "Run the following Python script:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:235
+#: ../../source/multibackend/npu/npu_installation.rst:257
+#: 35a6e05a53bf43b289f306c40d0a301c
 msgid "预期输出：``True``"
 msgstr "Expected output: ``True``"
 
-#: ../../source/multibackend/npu/npu_installation.rst:239
-msgid "该情况说明 ``HDK``、``CANN`` 和 ``torch_npu`` 都正常安装且生效。"
-msgstr "This indicates that ``HDK``, ``CANN``, and ``torch_npu`` are all installed correctly and functioning."
+#: ../../source/multibackend/npu/npu_installation.rst:261
+#: d849f79cca55494dbaf29ccd9d5a3620
+msgid "该情况说明 ``HDK``、``CANN`` 和 TorchNPU 都正常安装且生效。"
+msgstr "This indicates that ``HDK``, ``CANN``, and TorchNPU are installed correctly and working."
 
-#: ../../source/multibackend/npu/npu_installation.rst:245
+#: ../../source/multibackend/npu/npu_installation.rst:268
+#: c36dbbb71ec9401f8eb78634e3caf186
 msgid "方式二：Docker 预安装镜像"
 msgstr "Method 2: Docker Pre-installed Image"
 
-#: ../../source/multibackend/npu/npu_installation.rst:248
+#: ../../source/multibackend/npu/npu_installation.rst:271
+#: 8b8a00cdd707477bb957656d75663d22
 msgid "请确保宿主机已安装固件和驱动，可参考前文进行安装。"
 msgstr "Ensure the host has installed firmware and drivers; refer to the previous section for installation."
 
-#: ../../source/multibackend/npu/npu_installation.rst:251
-msgid "LLaMA-Factory 的官方镜像托管于 `Docker Hub <https://hub.docker.com/r/hiyouga/llamafactory/tags>`__ 和 `quay.io <https://quay.io/repository/ascend/llamafactory?tab=tags>`__，二者镜像无区别。"
-msgstr "LLaMA-Factory's official images are hosted on `Docker Hub <https://hub.docker.com/r/hiyouga/llamafactory/tags>`__ and `quay.io <https://quay.io/repository/ascend/llamafactory?tab=tags>`__; the images are identical."
+#: ../../source/multibackend/npu/npu_installation.rst:273
+#: 942abbaedfe54ac7b9d8bc026f28677d
+msgid "LlamaFactory 的官方镜像托管于 `Docker Hub <https://hub.docker.com/r/hiyouga/llamafactory/tags>`__ 和 `quay.io <https://quay.io/repository/ascend/llamafactory?tab=tags>`__，二者镜像无区别。"
+msgstr "LlamaFactory's official images are hosted on `Docker Hub <https://hub.docker.com/r/hiyouga/llamafactory/tags>`__ and `quay.io <https://quay.io/repository/ascend/llamafactory?tab=tags>`__; the images are identical."
 
-#: ../../source/multibackend/npu/npu_installation.rst:253
+#: ../../source/multibackend/npu/npu_installation.rst:276
+#: aa2eef96d6e84772b30b41c4b4f09a1e
 msgid "1. 拉取镜像"
 msgstr "1. Pull Image"
 
-#: ../../source/multibackend/npu/npu_installation.rst:256
-msgid "下载 main 分支最新镜像（请根据设备选择 A2 或 A3）。如需特定版本镜像，请访问镜像仓库查看 Tag。"
-msgstr "Download the latest image from the main branch (choose A2 or A3 according to your device). For specific version images, visit the image repository to check the tags."
+#: ../../source/multibackend/npu/npu_installation.rst:278
+#: bd2f65a7dc674cfab99fdecbe9872044
+msgid "下载 main 分支最新镜像时，需要同时根据设备和容器操作系统选择 Tag。A2 镜像在 Tag 中使用芯片标识 ``910b``，A3 镜像使用 ``a3``："
+msgstr "When downloading the latest image from the main branch, select the tag according to both the device and the container operating system. A2 images use the ``910b`` identifier in the tag, while A3 images use ``a3``:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:268
-msgid ""
+#: ../../source/multibackend/npu/npu_installation.rst:285
+#: ../../source/multibackend/npu/npu_installation.rst:420
+#: 9d0d13d466ca4732aa09e08d51a34f3a fe30a558a6e242c4bc99f30946dfba26
+msgid "硬件系列"
+msgstr "Hardware Series"
+
+#: ../../source/multibackend/npu/npu_installation.rst:286
+#: ../../source/multibackend/npu/npu_installation.rst:421
+#: ae787dd8a70246709f41ee44718dd3c8 085058d93506440c88af47fc1a3324a4
+msgid "容器操作系统"
+msgstr "Container Operating System"
+
+#: ../../source/multibackend/npu/npu_installation.rst:287
+#: 0fb86a38f6ae4f34883ee131052968b8
+msgid "Tag"
+msgstr "Tag"
+
+#: ../../source/multibackend/npu/npu_installation.rst:289
+#: ../../source/multibackend/npu/npu_installation.rst:292
+#: ../../source/multibackend/npu/npu_installation.rst:424
+#: ../../source/multibackend/npu/npu_installation.rst:427
+#: 68cb36e613514f79a467e05bd584fd52 1dcf0ffad03845ba801618b47703d61d
+#: b7c74412a616430ea7445bf8de09b7e6 dfce778c8fe04b75839d1a15a2e0f173
+msgid "Ubuntu 22.04"
 msgstr ""
 
-#: ../../source/multibackend/npu/npu_installation.rst:270
+#: ../../source/multibackend/npu/npu_installation.rst:290
+#: c077cec458cd49b1b805368465dd18dd
+msgid "``latest-910b-ubuntu``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:293
+#: 778c47671ef24d209491b42b9f48c913
+msgid "``latest-a3-ubuntu``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:295
+#: ../../source/multibackend/npu/npu_installation.rst:298
+#: ../../source/multibackend/npu/npu_installation.rst:430
+#: ../../source/multibackend/npu/npu_installation.rst:433
+#: 117ecb4697f04401b921a3f8cad05219 1ecf1ea0123b41cf963bb23b7da1887d
+#: a480ba1b10ad47b6992fbbaa5cf1ac4a 1f2e0b382ed045e192a085d5258d60a0
+msgid "openEuler 24.03"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:296
+#: 42a68395f3e2482f91bcd374a8fce435
+msgid "``latest-910b-openeuler``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:299
+#: 65d3a5e4e4d24678b50e73f4e1fb557e
+msgid "``latest-a3-openeuler``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:301
+msgid "根据上表确定 Tag 后，从 Docker Hub 或 quay.io 中选择一个镜像仓库，并执行对应的一条命令将镜像拉取到本地："
+msgstr "After determining the tag from the table above, select one image registry, either Docker Hub or quay.io, and run the corresponding command to pull the image locally:"
+
+#: ../../source/multibackend/npu/npu_installation.rst:315
+#: a9ef0d534d9441d98947838c5e0b9575
+msgid "``latest`` 镜像使用 ``latest-<910b|a3>-<ubuntu|openeuler>`` 格式，定时构建会更新这些 Tag。Release 镜像则使用包含完整版本信息的 Tag："
+msgstr "The ``latest`` images use the ``latest-<910b|a3>-<ubuntu|openeuler>`` format, and scheduled builds update these tags. Release images use tags containing the complete version information:"
+
+#: ../../source/multibackend/npu/npu_installation.rst:323
+#: ac1a4c738b65423c97b6f1c84a8e7351
 msgid "2. 启动容器"
 msgstr "2. Start Container"
 
-#: ../../source/multibackend/npu/npu_installation.rst:273
+#: ../../source/multibackend/npu/npu_installation.rst:325
+#: 28dafceb64d4476fab6b007314610628
 msgid "使用以下命令启动容器（请根据实际情况修改 ``DOCKER_IMAGE`` 和 ``device``）："
 msgstr "Start the container with the following command (modify ``DOCKER_IMAGE`` and ``device`` as appropriate):"
 
-#: ../../source/multibackend/npu/npu_installation.rst:385
+#: ../../source/multibackend/npu/npu_installation.rst:357
+#: 4b14aebfaa5f402f94c82117fe76074b
 msgid "配置 ``--privileged=true`` 可开启特权模式，赋予容器对底层硬件管理设备（如 ``/dev/davinci_manager``）的完整访问权限。这能解决多容器并行场景下，因权限限制导致的驱动初始化失败问题，确保 NPU 资源能被多个容器正常复用。"
 msgstr "Setting ``--privileged=true`` enables privileged mode, granting the container full access to hardware management devices (such as ``/dev/davinci_manager``). This resolves driver initialization failures in multi-container scenarios caused by permission restrictions, ensuring NPU resources can be reused across containers."
 
-#: ../../source/multibackend/npu/npu_installation.rst:389
+#: ../../source/multibackend/npu/npu_installation.rst:359
+#: 0a6b9e3910b94f55942113c6938ceb5b
 msgid "**注意**：若未配置该参数，可能会出现首个容器占用后，后续容器因无权限而无法读取设备的情况。鉴于特权模式的权限过大，生产环境中请务必评估安全风险后慎重使用。"
 msgstr "**Note**: Without this parameter, subsequent containers may fail to access devices due to insufficient permissions after the first container occupies them. Given the broad permissions of privileged mode, evaluate security risks carefully before using it in production."
 
-#: ../../source/multibackend/npu/npu_installation.rst:312
-msgid "3. 进入容器"
-msgstr "3. Enter Container"
+#: ../../source/multibackend/npu/npu_installation.rst:363
+#: db7b0c6c23824541924013cda36f7040
+msgid "3. 验证容器环境"
+msgstr "3. Verify the Container Environment"
 
-#: ../../source/multibackend/npu/npu_installation.rst:321
-msgid "通过 ``--device /dev/davinci<N>`` 挂载指定 NPU 卡（支持 0-7）。容器内设备编号会自动重新映射（例如物理机 davinci6 代表容器内设备 0）。"
-msgstr "Mount specified NPU cards using ``--device /dev/davinci<N>`` (supports 0–7). Device numbers inside the container are automatically remapped (e.g., physical machine davinci6 -> container device 0)."
+#: ../../source/multibackend/npu/npu_installation.rst:365
+#: bd9940491eee41b780a55987aaa0fe80
+msgid "容器启动后，进入容器："
+msgstr "After the container starts, enter it:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:323
-msgid "进入容器后，可使用 ``llamafactory-cli train`` 启动训练；如果当前 shell 尚未加载 Ascend 环境变量，请先执行 ``source /usr/local/Ascend/ascend-toolkit/set_env.sh``。"
-msgstr "After entering the container, you can start training with ``llamafactory-cli train``. If the current shell has not loaded the Ascend environment variables, run ``source /usr/local/Ascend/ascend-toolkit/set_env.sh`` first."
+#: ../../source/multibackend/npu/npu_installation.rst:371
+#: 2dbd8463592d4ae3a660b0d9531c4ffb
+msgid "然后加载 Ascend 环境，并检查软件版本、NPU 可用性与 LlamaFactory 命令："
+msgstr "Then load the Ascend environment and verify the software versions, NPU availability, and the LlamaFactory command:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:327
+#: ../../source/multibackend/npu/npu_installation.rst:382
+#: a10a7bdedc1546ada15e5efed2ccca31
+msgid "部分驱动环境中的 ``npu-smi`` 位于 ``/usr/local/sbin/npu-smi``，此时需要调整挂载源路径。通过 ``--device=/dev/davinci<N>`` 可挂载更多 NPU 设备。容器内设备编号会自动重新映射（例如物理机 davinci6 代表容器内设备 0）。"
+msgstr "In some driver environments, ``npu-smi`` is located at ``/usr/local/sbin/npu-smi``; in that case, adjust the source path of the mount. Use ``--device=/dev/davinci<N>`` to mount additional NPU devices. Device numbers are automatically remapped inside the container (for example, davinci6 on the host becomes device 0 in the container)."
+
+#: ../../source/multibackend/npu/npu_installation.rst:384
+#: 499ed452be714c40bd13e13739b17a2e
+msgid "环境验证通过后，可直接使用 ``llamafactory-cli train`` 启动训练。"
+msgstr "After the environment verification succeeds, you can start training directly with ``llamafactory-cli train``."
+
+#: ../../source/multibackend/npu/npu_installation.rst:389
+#: ec50be9e24eb43d58b0afe1eb9306f4c
 msgid "方式三：Docker 本地构建"
 msgstr "Method 3: Docker Local Build"
 
-#: ../../source/multibackend/npu/npu_installation.rst:331
+#: ../../source/multibackend/npu/npu_installation.rst:392
+#: b6b4ba8ac8e6481baeabf599012f390c
 msgid "请确保宿主机已安装固件和驱动。"
 msgstr "Ensure the host has installed firmware and drivers."
 
-#: ../../source/multibackend/npu/npu_installation.rst:333
-msgid "LLaMA-Factory 提供 :ref:`docker_build` 和 :ref:`docker_compose` 两种构建方式。"
-msgstr "LLaMA-Factory provides two build methods: :ref:`docker_build` and :ref:`docker_compose`."
+#: ../../source/multibackend/npu/npu_installation.rst:394
+#: 6bc7c7ac364e46baaf4f57d9dbbc0812
+msgid "LlamaFactory 提供 :ref:`docker_build` 和 :ref:`docker_compose` 两种构建方式。"
+msgstr "LlamaFactory provides two build methods: :ref:`docker_build` and :ref:`docker_compose`."
 
-#: ../../source/multibackend/npu/npu_installation.rst:338
+#: ../../source/multibackend/npu/npu_installation.rst:400
+#: 5a5cc1da41c145fd90a8525c00ab6b2f
 msgid "1. 使用 Docker Build 构建"
 msgstr "1. Build Using Docker Build"
 
-#: ../../source/multibackend/npu/npu_installation.rst:341
-msgid "构建镜像，在项目根目录下执行："
-msgstr "Build image — execute at the project root:"
+#: ../../source/multibackend/npu/npu_installation.rst:402
+#: 68cc60bce21645c69a034f877acd966b
+msgid "在项目根目录下执行以下命令，构建 A2 Ubuntu 镜像："
+msgstr "Run the following command in the project root to build an A2 Ubuntu image:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:352
-msgid "可修改 ``BASE_IMAGE`` 参数指定其他 CANN 版本（参考 `ascend/cann <https://quay.io/repository/ascend/cann?tab=tags&tag=latest>`__ ）。"
-msgstr "Modify the ``BASE_IMAGE`` parameter to specify other CANN versions (see `ascend/cann <https://quay.io/repository/ascend/cann?tab=tags&tag=latest>`__)."
+#: ../../source/multibackend/npu/npu_installation.rst:413
+#: f67be05f55b14088b6e428c9ce1ce044
+msgid "Dockerfile 默认使用 A2 Ubuntu 基础镜像。如需构建其他组合，可以替换 ``BASE_IMAGE`` 和本地镜像 Tag："
+msgstr "The Dockerfile uses an A2 Ubuntu base image by default. To build another combination, replace ``BASE_IMAGE`` and the local image tag:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:354
-msgid "启动容器"
-msgstr "Start container"
+#: ../../source/multibackend/npu/npu_installation.rst:422
+#: ../../source/multibackend/npu/npu_installation.rst:446
+#: 2a59e9dabb1c42e39e1d7bd4ef7ffccb 92a88b2f526643f4ba431756f891d499
+msgid "``BASE_IMAGE``"
+msgstr ""
 
-#: ../../source/multibackend/npu/npu_installation.rst:385
-msgid "配置 ``--privileged=true`` 可开启特权模式，赋予容器对底层硬件管理设备（如 ``/dev/davinci_manager``）的完整访问权限。这能解决多容器并行场景下，因权限限制导致的驱动初始化失败问题，确保 NPU 资源能被多个容器正常复用。"
-msgstr "Setting ``--privileged=true`` enables privileged mode, granting the container full access to hardware management devices (such as ``/dev/davinci_manager``). This resolves driver initialization failures in multi-container scenarios caused by permission restrictions, ensuring NPU resources can be reused across containers."
+#: ../../source/multibackend/npu/npu_installation.rst:425
+#: ../../source/multibackend/npu/npu_installation.rst:447
+#: 0a9f882980514a2da5f4a205dedf6afc 360b3e85297b4535b51ea2ad63ff4139
+msgid "``quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12``"
+msgstr ""
 
-#: ../../source/multibackend/npu/npu_installation.rst:389
-msgid "**注意**：若未配置该参数，可能会出现首个容器占用后，后续容器因无权限而无法读取设备的情况。鉴于特权模式的权限过大，生产环境中请务必评估安全风险后慎重使用。"
-msgstr "**Note**: Without this parameter, subsequent containers may fail to access devices due to insufficient permissions after the first container occupies them. Given the broad permissions of privileged mode, evaluate security risks carefully before using it in production."
+#: ../../source/multibackend/npu/npu_installation.rst:428
+#: b4713dcd9bad406c98f4738eda652a69
+msgid "``quay.io/ascend/cann:9.1.0-a3-ubuntu22.04-py3.12``"
+msgstr ""
 
-#: ../../source/multibackend/npu/npu_installation.rst:391
-msgid "(3) 进入容器"
-msgstr "(3) Enter container"
+#: ../../source/multibackend/npu/npu_installation.rst:431
+#: fce806e88a274477b0d79c4361a192d3
+msgid "``quay.io/ascend/cann:9.1.0-910b-openeuler24.03-py3.12``"
+msgstr ""
 
-#: ../../source/multibackend/npu/npu_installation.rst:399
+#: ../../source/multibackend/npu/npu_installation.rst:434
+#: 53607e60929b480ebf3c537f7bce776b
+msgid "``quay.io/ascend/cann:9.1.0-a3-openeuler24.03-py3.12``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:436
+#: 2fd55cfef4764cb1a721693e0f7030a2
+msgid "可用的 Dockerfile 构建参数如下："
+msgstr "The available Dockerfile build arguments are as follows:"
+
+#: ../../source/multibackend/npu/npu_installation.rst:443
+#: 445f373738a8404c960d0c98ad49dc6d
+msgid "参数"
+msgstr "Argument"
+
+#: ../../source/multibackend/npu/npu_installation.rst:444
+#: 249961e54638490197cac6f12523ad31
+msgid "默认值"
+msgstr "Default"
+
+#: ../../source/multibackend/npu/npu_installation.rst:445
+#: a4c08fed7a1b49dbb7c1c44c456f68d9
+msgid "用途"
+msgstr "Purpose"
+
+#: ../../source/multibackend/npu/npu_installation.rst:448
+#: b6e75728389d4cc1bbd9da0892a18f9a
+msgid "根据设备型号和容器操作系统选择对应的基础镜像"
+msgstr "Select the corresponding base image for the device model and container operating system"
+
+#: ../../source/multibackend/npu/npu_installation.rst:449
+#: a79aaf1e19084f91ad2e86a20d2e1726
+msgid "``PIP_INDEX``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:450
+#: d8d5171c0dba49999747b772607b8405
+msgid "``https://pypi.org/simple``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:451
+#: 1b162d49bcba4fa8af1a5a122a69c2ef
+msgid "指定 Python 软件包索引"
+msgstr "Specify the Python package index"
+
+#: ../../source/multibackend/npu/npu_installation.rst:452
+#: 188f307fbf994456a886edda19eee124
+msgid "``PYTORCH_INDEX``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:453
+#: 4d01f836537a4e0d87d4ed13a21f8d88
+msgid "``https://download.pytorch.org/whl/cpu``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:454
+#: 0c2baa8ac3c54634a17781d7d688308f
+msgid "指定配合 TorchNPU 使用的 PyTorch wheel 索引"
+msgstr "Specify the PyTorch wheel index used with TorchNPU"
+
+#: ../../source/multibackend/npu/npu_installation.rst:455
+#: 48d17646595746659dd3a0ac3e803011
+msgid "``HTTP_PROXY``"
+msgstr ""
+
+#: ../../source/multibackend/npu/npu_installation.rst:456
+#: 430752e178db4e428643e04f20d05d3a
+msgid "空"
+msgstr "Empty"
+
+#: ../../source/multibackend/npu/npu_installation.rst:457
+#: d1a6004c3cb543d39865b3a5603e4d95
+msgid "配置构建期间使用的 HTTP/HTTPS 代理"
+msgstr "Configure the HTTP/HTTPS proxy used during the build"
+
+#: ../../source/multibackend/npu/npu_installation.rst:459
+#: ab297336b9ac4862b541681081e792f9
+msgid "构建完成后，可以复用 :ref:`use_form_docker` 中的 ``docker run`` 命令，并将 ``DOCKER_IMAGE`` 设置为构建时通过 ``-t`` 指定的本地镜像名称。"
+msgstr "After the build completes, reuse the ``docker run`` command in :ref:`use_form_docker` and set ``DOCKER_IMAGE`` to the local image name specified with ``-t`` during the build."
+
+#: ../../source/multibackend/npu/npu_installation.rst:465
+#: 2b6ceffa86e74033ab353761c57a2b47
 msgid "2. 使用 Docker Compose 构建"
 msgstr "2. Build Using Docker Compose"
 
-#: ../../source/multibackend/npu/npu_installation.rst:402
+#: ../../source/multibackend/npu/npu_installation.rst:467
+#: 020195eb6bf94b6c876fa847a701edf4
 msgid "进入目录"
 msgstr "Enter directory"
 
-#: ../../source/multibackend/npu/npu_installation.rst:407
-msgid "构建镜像并直接启动容器，请根据设备型号选择命令："
-msgstr "Build image and start container directly — choose commands based on device model:"
+#: ../../source/multibackend/npu/npu_installation.rst:473
+#: 07c0e232f9ac442a96be52ac0eaa53bc
+msgid "启动容器。若本地镜像不存在，Docker Compose 会先构建镜像。请根据设备型号和容器操作系统选择 profile："
+msgstr "Start the container. If the image is not available locally, Docker Compose builds it first. Select a profile according to the device model and container operating system:"
 
-#: ../../source/multibackend/npu/npu_installation.rst:418
+#: ../../source/multibackend/npu/npu_installation.rst:489
+#: 88a4c3fde87f4429afe223990daf84f3
 msgid "进入容器"
 msgstr "Enter container"
 
-#: ../../source/multibackend/npu/npu_installation.rst:423
-msgid "构建前，请检查 `docker-compose.yml` 中的 `devices` 列表，当前构建时只会挂卡 0，请根据需要做修改。"
-msgstr "Before building, check the `devices` list in `docker-compose.yml`. Currently only card 0 is mounted during build; modify as needed."
+#: ../../source/multibackend/npu/npu_installation.rst:505
+#: a52fac5175cf4fdc8d3b87bfa6bdeef6
+msgid "如果只需要构建镜像而不启动容器，可以使用 ``docker compose --profile <profile> build``。"
+msgstr "To build the image without starting a container, use ``docker compose --profile <profile> build``."
 
+#: ../../source/multibackend/npu/npu_installation.rst:508
+#: f04a19720b8e4e6e8617b38805b261f5
+msgid "构建前，请检查 ``docker-compose.yml`` 中的 ``devices`` 列表，当前默认只会挂载卡 0，请根据需要修改。"
+msgstr "Before building, check the ``devices`` list in ``docker-compose.yml``. By default, only device 0 is mounted; modify the list as needed."

--- a/docs/locales/en/LC_MESSAGES/multibackend/npu/npu_training.po
+++ b/docs/locales/en/LC_MESSAGES/multibackend/npu/npu_training.po
@@ -1,498 +1,533 @@
-# English translations for LLaMA Factory.
-# Copyright (C) 2026 ORGANIZATION
-# This file is distributed under the same license as the LLaMA Factory project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, LlamaFactory team.
+# This file is distributed under the same license as the LlamaFactory
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: LLaMA Factory VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-05-09 17:34+0800\n"
+"Project-Id-Version: LlamaFactory \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-07 18:08+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: OpenAI <support@openai.com>\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
 "Language: en\n"
-"Language-Team: English\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: Babel 2.16.0\n"
 
-#: ../../source/multibackend/npu/npu_training.rst:2 1da3d9ca6ffb41c487f5ba4f39c84e1a
+#: ../../source/multibackend/npu/npu_training.rst:2
+#: 773f1b6651f74fde95cc3067fe1d9d1d
 msgid "NPU训练"
 msgstr "NPU Training"
 
-#: ../../source/multibackend/npu/npu_training.rst:4 aafed391eac84edf9a23677020ae1105
-msgid "本文档介绍如何在华为昇腾 NPU 上进行 LLaMA-Factory 模型训练。"
-msgstr "This document describes how to perform LLaMA-Factory model training on Huawei Ascend NPU."
+#: ../../source/multibackend/npu/npu_training.rst:4
+#: d2274cbcacd945469a743199cacc492e
+msgid "本文档介绍如何在华为昇腾 NPU 上进行 LlamaFactory 模型训练。"
+msgstr "This document describes how to perform LlamaFactory model training on Huawei Ascend NPU."
 
-#: ../../source/multibackend/npu/npu_training.rst:7 11fcfa7b6b0d4d0ca8139669a2a7ffcc
+#: ../../source/multibackend/npu/npu_training.rst:7
+#: a14a253ead0c4421b8086aff98852b1f
 msgid "支持设备"
 msgstr "Supported Devices"
 
-#: ../../source/multibackend/npu/npu_training.rst:9 00fe6b58e9614db19732925d7fab162a
-msgid "LLaMA-Factory 当前已适配以下昇腾 NPU 设备："
-msgstr "LLaMA-Factory currently supports the following Ascend NPU devices:"
+#: ../../source/multibackend/npu/npu_training.rst:9
+#: 4656604e347443f4b412d711d2feb620
+msgid "LlamaFactory 当前已适配以下昇腾 NPU 设备："
+msgstr "LlamaFactory currently supports the following Ascend NPU devices:"
 
-#: ../../source/multibackend/npu/npu_training.rst:11 a3b479b674984d629878fe19de92cb18
+#: ../../source/multibackend/npu/npu_training.rst:11
+#: 0fe7c55ce8bc448c8a3be15f03eb2053
 msgid "**Atlas A2 训练系列**"
 msgstr "**Atlas A2 Training Series**"
 
-#: ../../source/multibackend/npu/npu_training.rst:12 86ef64b396be40d69c7097f315e66b47
+#: ../../source/multibackend/npu/npu_training.rst:12
+#: d219909822bd425186c43f9d3ca2f35c
 msgid "**Atlas A3 训练系列**"
 msgstr "**Atlas A3 Training Series**"
 
-#: ../../source/multibackend/npu/npu_training.rst:15 390270a6db69437f87ab70593a08aab5
+#: ../../source/multibackend/npu/npu_training.rst:15
+#: f3954b9817034da694d3a10d6d8808d3
 msgid "支持功能"
 msgstr "Supported Features"
 
-#: ../../source/multibackend/npu/npu_training.rst:23 6f3c9a72232440b3a42e6f17a07f6119
+#: ../../source/multibackend/npu/npu_training.rst:23
+#: 67bfdd62b5b14fe895795326499ef199
 msgid "功能"
 msgstr "Feature"
 
-#: ../../source/multibackend/npu/npu_training.rst:24 48876c89203547a39f2bd9df16a6c85e
+#: ../../source/multibackend/npu/npu_training.rst:24
+#: c624ca3122324d569a3a751ce5a0ec8e
 msgid "支持情况"
 msgstr "Support Status"
 
-#: ../../source/multibackend/npu/npu_training.rst:25 84079f448600445d8f7c1cc4e7832280
+#: ../../source/multibackend/npu/npu_training.rst:25
+#: 2a72843fdf0043859f678e90822ee2b6
 msgid "**训练范式**"
 msgstr "**Training Paradigm**"
 
-#: ../../source/multibackend/npu/npu_training.rst:26 33e84e4f5d5946598160f79980e12b51
+#: ../../source/multibackend/npu/npu_training.rst:26
+#: 0b600dc7ccec4dc686fcd8ac5b964332
 msgid "PT"
 msgstr "PT"
 
-#: ../../source/multibackend/npu/npu_training.rst:27 ../../source/multibackend/npu/npu_training.rst:30
-#: ../../source/multibackend/npu/npu_training.rst:33 ../../source/multibackend/npu/npu_training.rst:36
-#: ../../source/multibackend/npu/npu_training.rst:39 ../../source/multibackend/npu/npu_training.rst:42
-#: ../../source/multibackend/npu/npu_training.rst:45 ../../source/multibackend/npu/npu_training.rst:48
-#: ../../source/multibackend/npu/npu_training.rst:51 ../../source/multibackend/npu/npu_training.rst:54
-#: ../../source/multibackend/npu/npu_training.rst:57 ../../source/multibackend/npu/npu_training.rst:60
-#: 02820aa7d56e4d81b4e6432d6a1dd78f 42c95f32bb7a45e2892ebc5dea3da504 4b7318cab7414db8adb95896066ae153
-#: 5829734a75dd453da5f1e823b7112217 921805fd58d248318d65b5514e949517 9ecaa953d02e4ce6807d0ca510953129
-#: b03e12a3088942448cddc76b7333db22 cb92ffe50c974658b42c29cbdbd3dd2e cc81bbc78719498482d504d3af2e1952
-#: d3ef863a2c2c49f5a3081a38eaa39246 d5e41833c09b49398be2d8687cab83bd feb04dee92654e6fbc6ad833cac6c45e
+#: ../../source/multibackend/npu/npu_training.rst:27
+#: ../../source/multibackend/npu/npu_training.rst:30
+#: ../../source/multibackend/npu/npu_training.rst:33
+#: ../../source/multibackend/npu/npu_training.rst:36
+#: ../../source/multibackend/npu/npu_training.rst:39
+#: ../../source/multibackend/npu/npu_training.rst:42
+#: ../../source/multibackend/npu/npu_training.rst:45
+#: ../../source/multibackend/npu/npu_training.rst:48
+#: ../../source/multibackend/npu/npu_training.rst:51
+#: ../../source/multibackend/npu/npu_training.rst:54
+#: ../../source/multibackend/npu/npu_training.rst:57
+#: ../../source/multibackend/npu/npu_training.rst:60
+#: cff7477264d64aca93f1f8cd71400a77 d2fe870c1ab848f8b3d34e308838af44
+#: dab292c9075f4d66a74722920df36d8b 7f4b58f012664327b630392a905e2687
+#: 35f747d16032499fb0e80a0b3f7bbcb4 db47d1d69c9946e4a2f8c5c134bef17b
+#: a3a4a696ed9546479624a064ba0681d5 6f36721e8f434d13b4eacbe1d78c4989
+#: 9593cbe6eab5498daf441d39941c4cb4 90c14343e9124c5b96b9cb0d439c2815
+#: 11a737be94e14674bef55bae20d027c4 3e4f1e3c08b1441e9d51ce3511a728e0
 msgid "已支持"
 msgstr "Supported"
 
-#: ../../source/multibackend/npu/npu_training.rst:29 93b4d0bf2b844a279345df5c2e08d85d
+#: ../../source/multibackend/npu/npu_training.rst:29
+#: 66ab39f1fabd490bb7b71a618a4813e9
 msgid "SFT"
 msgstr "SFT"
 
-#: ../../source/multibackend/npu/npu_training.rst:32 f9d9fc2cab604718a34ba4c1b738ddf6
+#: ../../source/multibackend/npu/npu_training.rst:32
+#: ebba33ff9db44a24ba2bdd1cdfcb13f1
 msgid "RM"
 msgstr "RM"
 
-#: ../../source/multibackend/npu/npu_training.rst:35 c4bdd0f46953484eae08d6ed1576c953
+#: ../../source/multibackend/npu/npu_training.rst:35
+#: edc4e8b2bdc047ff8924f75ceef344f0
 msgid "DPO"
 msgstr "DPO"
 
-#: ../../source/multibackend/npu/npu_training.rst:37 5e5b569a3ab140d5acaa6134aafc745c
+#: ../../source/multibackend/npu/npu_training.rst:37
+#: d7b48c5b0b5c4b639c167853f5e16fdc
 msgid "**参数范式**"
 msgstr "**Parameter Paradigm**"
 
-#: ../../source/multibackend/npu/npu_training.rst:38 a18f10c54dfe461d8caf6b63004e02c8
+#: ../../source/multibackend/npu/npu_training.rst:38
+#: e159a577eff548aea63a000dd2a88da9
 msgid "Full"
 msgstr "Full"
 
-#: ../../source/multibackend/npu/npu_training.rst:41 f5443206fed44b0ebbe398f79bb6f23f
+#: ../../source/multibackend/npu/npu_training.rst:41
+#: 51bfc967a24546fb83380198ac969ef5
 msgid "Freeze"
 msgstr "Freeze"
 
-#: ../../source/multibackend/npu/npu_training.rst:44 5fcb9537dc8d486c960ed16cea4d6abf
+#: ../../source/multibackend/npu/npu_training.rst:44
+#: a4156a9459934003872e889ab34f12a0
 msgid "LoRA"
 msgstr "LoRA"
 
-#: ../../source/multibackend/npu/npu_training.rst:46 4486adcc4d0d4237be369bead6347a70
+#: ../../source/multibackend/npu/npu_training.rst:46
+#: 80590d9b527f4b03bc99304ce21561f0
 msgid "**模型合并**"
 msgstr "**Model Merging**"
 
-#: ../../source/multibackend/npu/npu_training.rst:47 4fdd79f89c7b4b46ad533a4a7c9f03d2
+#: ../../source/multibackend/npu/npu_training.rst:47
+#: 3a2e747f5efe4f09a30d4c7a66017cd9
 msgid "LoRA权重合并"
 msgstr "LoRA Weight Merging"
 
-#: ../../source/multibackend/npu/npu_training.rst:49 3a03bed801f74c358923ed322d83bdff
+#: ../../source/multibackend/npu/npu_training.rst:49
+#: fff67a835efb408baeeea92aaed971f0
 msgid "**分布式**"
 msgstr "**Distributed**"
 
-#: ../../source/multibackend/npu/npu_training.rst:50 2cb4aadbbccc4f16902acffb86bd9318
+#: ../../source/multibackend/npu/npu_training.rst:50
+#: 6976080b9a6e4369bcd5a10544b3d207
 msgid "DDP"
 msgstr "DDP"
 
-#: ../../source/multibackend/npu/npu_training.rst:53 b76cfc1438844c9c9ab3eb97ffb3ac07
+#: ../../source/multibackend/npu/npu_training.rst:53
+#: af86deb51c6c43878ef913bab0f8bd1f
 msgid "FSDP"
 msgstr "FSDP"
 
-#: ../../source/multibackend/npu/npu_training.rst:56 f6bcbbfa4190419aa1b4a6c8ea9f434c
+#: ../../source/multibackend/npu/npu_training.rst:56
+#: c6ca7aae2939410e893177e07bcc1416
 msgid "FSDP2"
 msgstr "FSDP2"
 
-#: ../../source/multibackend/npu/npu_training.rst:59 66f16ddc336646c3a62c6e2f6b4de71e
+#: ../../source/multibackend/npu/npu_training.rst:59
+#: 653a492340d64cc7aa79fc1d818fbd24
 msgid "DeepSpeed"
 msgstr "DeepSpeed"
 
-#: ../../source/multibackend/npu/npu_training.rst:61 068e921d0afe40418dea39ce88818660
+#: ../../source/multibackend/npu/npu_training.rst:61
+#: c5dcd47e2a8f4b0c935fcc5853dd2ea5
 msgid "**加速**"
 msgstr "**Acceleration**"
 
-#: ../../source/multibackend/npu/npu_training.rst:62 ../../source/multibackend/npu/npu_training.rst:271
-#: ../../source/multibackend/npu/npu_training.rst:295 a46bfd6f7177415892fd5352e62470d9
-#: ed8e41aad7764ee1b0be94bd861baca9
+#: ../../source/multibackend/npu/npu_training.rst:62
+#: ../../source/multibackend/npu/npu_training.rst:291
+#: ../../source/multibackend/npu/npu_training.rst:315
+#: 4094328be4fd446e82820140527cf004 cbaa69da9a264c01afbc61fbdb3c8d4c
+#: c685f22aac8747bd8f399eff70892bee
 msgid "融合算子"
 msgstr "Fused Operators"
 
-#: ../../source/multibackend/npu/npu_training.rst:63 8fd591f6bcdc48fd943cec014d5cc798
-msgid "当前已支持NpuFusedRMSNorm，NpuFusedSwiGlu，NpuFusedRoPE，NpuFusedMoE"
-msgstr "Currently supports NpuFusedRMSNorm, NpuFusedSwiGlu, NpuFusedRoPE, NpuFusedMoE"
+#: ../../source/multibackend/npu/npu_training.rst:63
+#: d0e16c4f90c54dbb9a29741fc6a157d5
+msgid "当前已支持 FA、NpuFusedRMSNorm、NpuFusedSwiGlu、NpuFusedRoPE、NpuFusedMoE"
+msgstr "Currently supports FA, NpuFusedRMSNorm, NpuFusedSwiGlu, NpuFusedRoPE, and NpuFusedMoE"
 
-#: ../../source/multibackend/npu/npu_training.rst:66 548b7b4da30349f0b333b14e40490586
-msgid ""
-"NPU 的大部分使用方式与 GPU 保持一致。关于通用的安装步骤，请参考 :doc:`NPU 安装及配置 <npu_installation>`；关于通用的分布式训练（如 "
-"FSDP、FSDP2，DeepSpeed）配置，请参考 :doc:`分布式训练 <../../advanced/distributed>`。"
-msgstr ""
-"Most NPU usage is consistent with GPU usage. For general installation steps, refer to :doc:`NPU "
-"Installation and Configuration <npu_installation>`; for general distributed training configurations"
-" (such as FSDP, FSDP2, DeepSpeed), refer to :doc:`Distributed Training "
-"<../../advanced/distributed>`."
+#: ../../source/multibackend/npu/npu_training.rst:66
+#: 4c485280060f4474ab2160e29336f773
+msgid "NPU 的大部分使用方式与 GPU 保持一致。关于通用的安装步骤，请参考 :doc:`NPU 安装及配置 <npu_installation>`；关于通用的分布式训练（如 FSDP、FSDP2，DeepSpeed）配置，请参考 :doc:`分布式训练 <../../advanced/distributed>`。"
+msgstr "Most NPU usage is consistent with GPU usage. For general installation steps, refer to :doc:`NPU Installation and Configuration <npu_installation>`; for general distributed training configurations (such as FSDP, FSDP2, DeepSpeed), refer to :doc:`Distributed Training <../../advanced/distributed>`."
 
-#: ../../source/multibackend/npu/npu_training.rst:69 022e4b47e24f4b43958842de626ae839
+#: ../../source/multibackend/npu/npu_training.rst:69
+#: 0deb6a3de68d4bd1818efcdc91e29491
 msgid "快速开始"
 msgstr "Quick Start"
 
-#: ../../source/multibackend/npu/npu_training.rst:71 d14b4602727f44418fdd259a217c149f
-msgid "为了快速上手，建议直接使用 LLaMA-Factory 提供的 Docker 镜像。"
-msgstr "To get started quickly, it is recommended to use the Docker image provided by LLaMA-Factory."
+#: ../../source/multibackend/npu/npu_training.rst:71
+#: a148380aaed84c10babfa530b57fca56
+msgid "为了快速上手，建议直接使用 LlamaFactory 提供的 Docker 镜像。以下示例使用 A2 Ubuntu 镜像 ``latest-910b-ubuntu``；其他硬件和容器操作系统组合请参考 :doc:`NPU 安装及配置 <npu_installation>`。"
+msgstr "To get started quickly, we recommend using a Docker image provided by LlamaFactory. The following example uses the A2 Ubuntu image ``latest-910b-ubuntu``; for other hardware and container operating system combinations, see :doc:`NPU Installation and Configuration <npu_installation>`."
 
-#: ../../source/multibackend/npu/npu_training.rst:73 c52284fdf1dc4711a9051b43d70cd981
+#: ../../source/multibackend/npu/npu_training.rst:73
+#: aab1269846214bb5b888754a131c5ad6
 msgid "**启动容器** (请根据实际情况修改 ``device`` 映射)："
 msgstr "**Start the container** (modify the ``device`` mapping as needed):"
 
-#: ../../source/multibackend/npu/npu_training.rst:90 51cf626f1ce543ab90930440129d2b20
-msgid "**配置环境变量**："
-msgstr "**Configure environment variables**:"
+#: ../../source/multibackend/npu/npu_training.rst:94
+#: cd41dc8c0f62467999f83b6cfecb2187
+msgid "**进入容器并配置环境变量**："
+msgstr "**Enter the container and configure environment variables**:"
 
-#: ../../source/multibackend/npu/npu_training.rst:92 d1aed85b2ce6411f84d49de627f4fb87
+#: ../../source/multibackend/npu/npu_training.rst:100
+#: 0a333534e775481bac1710f9d615da98
 msgid "进入容器后，**务必** 先加载 Ascend 环境配置，否则无法识别 NPU 设备："
-msgstr ""
-"After entering the container, **be sure** to load the Ascend environment configuration first; "
-"otherwise, NPU devices will not be recognized."
+msgstr "After entering the container, **be sure** to load the Ascend environment configuration first; otherwise, NPU devices will not be recognized."
 
-#: ../../source/multibackend/npu/npu_training.rst:99 9b9605d784db4486bfb8723fe8e0fe67
+#: ../../source/multibackend/npu/npu_training.rst:106
+#: e18d29af5a15440a9bad43f82c422a64
 msgid "**开始训练**："
 msgstr "**Start training**:"
 
-#: ../../source/multibackend/npu/npu_training.rst:101 11b7b975b66644bcb39dfc554ba56b56
+#: ../../source/multibackend/npu/npu_training.rst:109
+#: 621288c596e0476b89db9490dcd7e78d
 msgid "下载模型时，如果无法顺利访问 Hugging Face 社区资源下载，推荐前往 ModelScope 下载，或按需配置以下参数："
-msgstr ""
-"When downloading models, if you cannot access Hugging Face community resources smoothly, we "
-"recommend downloading them from ModelScope or configuring the following parameters as needed:"
+msgstr "When downloading models, if you cannot access Hugging Face community resources smoothly, we recommend downloading them from ModelScope or configuring the following parameters as needed:"
 
-#: ../../source/multibackend/npu/npu_training.rst:103 3f2daff9f9564772a5c71d3af1553461
+#: ../../source/multibackend/npu/npu_training.rst:111
+#: 9e874b763476411e805c8e2559938365
 msgid "设置 ``USE_MODELSCOPE_HUB`` 环境变量，优先使用 ModelScope 下载模型/数据集或使用缓存路径中的模型/数据集："
-msgstr ""
-"Set the ``USE_MODELSCOPE_HUB`` environment variable to prioritize downloading models/datasets "
-"from ModelScope or using models/datasets from the cache path:"
+msgstr "Set the ``USE_MODELSCOPE_HUB`` environment variable to prioritize downloading models/datasets from ModelScope or using models/datasets from the cache path:"
 
-#: ../../source/multibackend/npu/npu_training.rst:109 a82950bcbd53423b863bfa0850cf4e12
+#: ../../source/multibackend/npu/npu_training.rst:117
+#: 41dc24e6cebc4f0aa7315396c0e4316a
 msgid "如需访问受限或私有的 ModelScope Hub 资源，可配置 ``ms_hub_token``。"
 msgstr "To access restricted or private ModelScope Hub resources, configure ``ms_hub_token``."
 
-#: ../../source/multibackend/npu/npu_training.rst:111 115619b93b0148088bde78c0e5eb61aa
+#: ../../source/multibackend/npu/npu_training.rst:119
+#: cb134e997c2146058a113d873d68bbae
 msgid "更多参数说明请参考 :doc:`参数介绍 <../../advanced/arguments>`。下载前需关注待下载文件的正确性与安全性。"
-msgstr ""
-"For more parameter details, refer to :doc:`Arguments <../../advanced/arguments>`. Before "
-"downloading, pay attention to the correctness and security of the files to be downloaded."
+msgstr "For more parameter details, refer to :doc:`Arguments <../../advanced/arguments>`. Before downloading, pay attention to the correctness and security of the files to be downloaded."
 
-#: ../../source/multibackend/npu/npu_training.rst:106 6002060779a34fb2895a072077698b6a
+#: ../../source/multibackend/npu/npu_training.rst:126
+#: 1feed703cc8243debe77af0d00595589
 msgid "常用调参建议"
 msgstr "Common Tuning Tips"
 
-#: ../../source/multibackend/npu/npu_training.rst:108 cfa5ade8d57a465ab9c5f9ce284892c7
+#: ../../source/multibackend/npu/npu_training.rst:128
+#: f6023222c3f6483b9141fa079bfb0f7e
 msgid "如果希望在显存占用和训练吞吐之间做简单取舍，建议优先关注以下参数："
-msgstr ""
-"If you want a simple trade-off between memory usage and training throughput, start by focusing on"
-" the following parameters:"
+msgstr "If you want a simple trade-off between memory usage and training throughput, start by focusing on the following parameters:"
 
-#: ../../source/multibackend/npu/npu_training.rst:110 9ff0328fe91442f19d2ef70b9ee73d15
+#: ../../source/multibackend/npu/npu_training.rst:130
+#: b1510a38cd684e4ba6858f6707a5738c
 msgid "``per_device_train_batch_size``：单卡 batch size。调大通常可以提升吞吐，但会直接增加显存占用；如果出现 OOM，优先先把它调小。"
-msgstr ""
-"``per_device_train_batch_size``: per-device batch size. Increasing it usually improves throughput, "
-"but directly increases memory usage. If OOM occurs, reduce it first."
+msgstr "``per_device_train_batch_size``: per-device batch size. Increasing it usually improves throughput, but directly increases memory usage. If OOM occurs, reduce it first."
 
-#: ../../source/multibackend/npu/npu_training.rst:111 d21038d6525e4fae8cd947fa9e290373
-msgid ""
-"``gradient_accumulation_steps``：梯度累积步数。在减小 ``per_device_train_batch_size`` 后，可以适当调大该参数，以尽量保持原本的有效"
-" batch size；但累积步数越大，单次参数更新越慢。"
-msgstr ""
-"``gradient_accumulation_steps``: number of gradient accumulation steps. After reducing "
-"``per_device_train_batch_size``, you can increase this parameter to keep the original effective "
-"batch size as much as possible. However, the larger the accumulation steps, the slower each "
-"parameter update becomes."
+#: ../../source/multibackend/npu/npu_training.rst:131
+#: 95c61bf75b5249bb8a82191b3d01e0fa
+msgid "``gradient_accumulation_steps``：梯度累积步数。在减小 ``per_device_train_batch_size`` 后，可以适当调大该参数，以尽量保持原本的有效 batch size；但累积步数越大，单次参数更新越慢。"
+msgstr "``gradient_accumulation_steps``: number of gradient accumulation steps. After reducing ``per_device_train_batch_size``, you can increase this parameter to keep the original effective batch size as much as possible. However, the larger the accumulation steps, the slower each parameter update becomes."
 
-#: ../../source/multibackend/npu/npu_training.rst:112 06e9acd4d43a43fb9b2fd710377fdcce
+#: ../../source/multibackend/npu/npu_training.rst:132
+#: 8bec49565aa24279a1955e8711d60244
 msgid "``cutoff_len``：样本截断长度。它通常是影响显存占用最明显的参数之一，尤其在长上下文训练时；如果当前任务不依赖超长输入，建议先适当减小。"
-msgstr ""
-"``cutoff_len``: sample truncation length. This is usually one of the most important parameters "
-"affecting memory usage, especially for long-context training. If the current task does not depend "
-"on very long inputs, reduce it first."
+msgstr "``cutoff_len``: sample truncation length. This is usually one of the most important parameters affecting memory usage, especially for long-context training. If the current task does not depend on very long inputs, reduce it first."
 
-#: ../../source/multibackend/npu/npu_training.rst:113 6772d1986dc549328d8a1c9647b96a4d
+#: ../../source/multibackend/npu/npu_training.rst:133
+#: 1fe9bcb46fb9452290c328eacbd24409
 msgid "``gradient_checkpointing``：梯度检查点。开启后通常可以明显降低显存占用，但会带来一定的速度损失，适合显存较紧张的场景。"
-msgstr ""
-"``gradient_checkpointing``: gradient checkpointing. Enabling it usually significantly reduces "
-"memory usage, but introduces some speed loss. It is suitable for memory-constrained scenarios."
+msgstr "``gradient_checkpointing``: gradient checkpointing. Enabling it usually significantly reduces memory usage, but introduces some speed loss. It is suitable for memory-constrained scenarios."
 
-#: ../../source/multibackend/npu/npu_training.rst:115 47e4f75cb8b84c10a7350ac6dda4828d
+#: ../../source/multibackend/npu/npu_training.rst:135
+#: 3b1b422e4b2e4015897e28acf0c381e0
 msgid "下面给出一个更偏向“先跑通、少占显存”的示例配置："
-msgstr ""
-"The following example is a more conservative starting point that prioritizes getting the run "
-"working while using less memory:"
+msgstr "The following example is a more conservative starting point that prioritizes getting the run working while using less memory:"
 
-#: ../../source/multibackend/npu/npu_training.rst:125 5fdb8448b60243cb8afebe4614808c39
+#: ../../source/multibackend/npu/npu_training.rst:145
+#: 51211ec68f694d698ecb16ec4ef041de
 msgid "分布式训练"
 msgstr "Distributed Training"
 
-#: ../../source/multibackend/npu/npu_training.rst:127 2cfc5ebdb6d04d5bac919188fe73b384
-msgid ""
-"NPU 的分布式训练配置与 :doc:`分布式训练 <../../advanced/distributed>` 文档描述的基本一致。本节主要介绍 NPU "
-"环境下的特定配置，包括设备指定和多机通信设置。"
-msgstr ""
-"NPU distributed training configuration is generally consistent with the :doc:`Distributed Training "
-"<../../advanced/distributed>` document. This section introduces NPU-specific configurations, "
-"including device selection and multi-node communication settings."
+#: ../../source/multibackend/npu/npu_training.rst:147
+#: 4ec3ca97df534669a1aeefcd70063341
+msgid "NPU 的分布式训练配置与 :doc:`分布式训练 <../../advanced/distributed>` 文档描述的基本一致。本节主要介绍 NPU 环境下的特定配置，包括设备指定和多机通信设置。"
+msgstr "NPU distributed training configuration is generally consistent with the :doc:`Distributed Training <../../advanced/distributed>` document. This section introduces NPU-specific configurations, including device selection and multi-node communication settings."
 
-#: ../../source/multibackend/npu/npu_training.rst:130 dff1da64f75049f9b8d3b188cfedc3ad
+#: ../../source/multibackend/npu/npu_training.rst:150
+#: eea86bb7fadb4a6ab4f7e976aeafe349
 msgid "关键环境变量"
 msgstr "Key Environment Variables"
 
-#: ../../source/multibackend/npu/npu_training.rst:132 ed2f0f44d75546259f34941e0a8db0f5
+#: ../../source/multibackend/npu/npu_training.rst:152
+#: 3516a2c8a4284faa9d089f58fe90ae1f
 msgid "在启动训练前，请注意以下环境变量的设置："
 msgstr "Before starting training, pay attention to the following environment variable settings:"
 
-#: ../../source/multibackend/npu/npu_training.rst:134 14d3d8b5489a417189bd7501ddda36bb
+#: ../../source/multibackend/npu/npu_training.rst:154
+#: 47ef452a31e04a3f946e4a0ecd9d0b5f
 msgid "**ASCEND_RT_VISIBLE_DEVICES** (单机/多机均需关注)"
 msgstr "**ASCEND_RT_VISIBLE_DEVICES** (required for single-node and multi-node)"
 
-#: ../../source/multibackend/npu/npu_training.rst:136 948333b0e6e14d59a63d5b755e06c82d
+#: ../../source/multibackend/npu/npu_training.rst:156
+#: e364b7586b0a48038408becd168ac6ae
 msgid "用于指定参与训练的 NPU 设备。"
 msgstr "Used to specify NPU devices participating in training."
 
-#: ../../source/multibackend/npu/npu_training.rst:138 7be25e8f29724d1d91485708f35aca28
+#: ../../source/multibackend/npu/npu_training.rst:158
+#: 7839588ba62a49aaa6eadd81a85cfda0
 msgid "**默认行为**：如果不设置此变量，程序将尝试使用当前节点上的**所有** NPU 设备。"
-msgstr ""
-"**Default behavior**: If this variable is not set, the program will attempt to use **all** NPU "
-"devices on the current node."
+msgstr "**Default behavior**: If this variable is not set, the program will attempt to use **all** NPU devices on the current node."
 
-#: ../../source/multibackend/npu/npu_training.rst:139 fb1141427944412485abedd9869ecef2
+#: ../../source/multibackend/npu/npu_training.rst:159
+#: 37f3cc87582340419e56fe7bef2beea1
 msgid "**指定设备**：如果需要限定特定的 NPU 卡（例如仅使用卡 0 和卡 1），则**必须**显式设置此变量："
-msgstr ""
-"**Specify devices**: If you need to limit training to specific NPU cards (e.g., only card 0 and "
-"card 1), you **must** explicitly set this variable:"
+msgstr "**Specify devices**: If you need to limit training to specific NPU cards (e.g., only card 0 and card 1), you **must** explicitly set this variable:"
 
-#: ../../source/multibackend/npu/npu_training.rst:145 f6ff2e067d0247eeb915ed88a9d2f007
+#: ../../source/multibackend/npu/npu_training.rst:165
+#: f0cb26b4ccdf4d09a7920df6aafaf5e2
 msgid "**HCCL_SOCKET_IFNAME** (仅多机训练必需)"
 msgstr "**HCCL_SOCKET_IFNAME** (required for multi-node training only)"
 
-#: ../../source/multibackend/npu/npu_training.rst:147 3c90a0201d1449c8a92436a8227d6703
+#: ../../source/multibackend/npu/npu_training.rst:167
+#: bf05cf41f96e4bfd836ccd9992ef7968
 msgid "指定 HCCL 集合通信使用的网卡接口名称。"
 msgstr "Specifies the network interface name used for HCCL collective communication."
 
-#: ../../source/multibackend/npu/npu_training.rst:149 df742a91976844d39f3dc0785be06578
+#: ../../source/multibackend/npu/npu_training.rst:169
+#: 1ad70f4842354b5c9a6b7425829a931b
 msgid "**获取方式**：在终端运行 ``ifconfig`` 命令查看网卡列表，选择用于通信的网卡名称（如 ``eth0``, ``enp1s0`` 等）。"
-msgstr ""
-"**How to obtain**: Run ``ifconfig`` in the terminal to view the network interface list, and "
-"choose the interface used for communication (e.g., ``eth0``, ``enp1s0``)."
+msgstr "**How to obtain**: Run ``ifconfig`` in the terminal to view the network interface list, and choose the interface used for communication (e.g., ``eth0``, ``enp1s0``)."
 
-#: ../../source/multibackend/npu/npu_training.rst:150 a07ef45f73f34dc4a1f87ca10ebfc5cc
+#: ../../source/multibackend/npu/npu_training.rst:170
+#: ec4c5944151a462aaf75a9ca090c7266
 msgid "**设置示例**："
 msgstr "**Example setting**:"
 
-#: ../../source/multibackend/npu/npu_training.rst:157 b9ddb1de8e9e4174831e7405f80342e9
+#: ../../source/multibackend/npu/npu_training.rst:177
+#: d477ef5aa7f84f5089f588aa6838cf92
 msgid "单机训练"
 msgstr "Single-Node Training"
 
-#: ../../source/multibackend/npu/npu_training.rst:159 10af9c756fe3414d93f3f64f173b66fd
+#: ../../source/multibackend/npu/npu_training.rst:179
+#: c69b5a99ef7746b6b00a9180ddcf4c45
 msgid "单机训练（单卡或多卡）的启动方式与标准流程一致。"
 msgstr "Single-node training (single card or multiple cards) follows the standard procedure."
 
-#: ../../source/multibackend/npu/npu_training.rst:161 6345cd6e0beb408bac7114edfc4e0e12
+#: ../../source/multibackend/npu/npu_training.rst:181
+#: 9894bb94773a46818892ff248ac7522b
 msgid "**单机多卡示例**："
 msgstr "**Single-node multi-card example**:"
 
-#: ../../source/multibackend/npu/npu_training.rst:168 33554b400853495e99dc0dcc836bef13
+#: ../../source/multibackend/npu/npu_training.rst:188
+#: 74b6818244064c34b620b161ca0bdfaf
 msgid "多机训练"
 msgstr "Multi-node Training"
 
-#: ../../source/multibackend/npu/npu_training.rst:170 70b52990c40341379fbbcffd32e0fb68
+#: ../../source/multibackend/npu/npu_training.rst:190
+#: 3477bbc4d25d407a803096d4d9029549
 msgid "在 NPU 环境下，推荐使用 ``accelerate launch`` 配合 FSDP 1/2 进行多机训练，这种方式在 NPU 上通信和计算效率更优。"
-msgstr ""
-"In NPU environments, it is recommended to use ``accelerate launch`` with FSDP 1/2 for multi-node "
-"training; this approach provides better communication and computation efficiency on NPU."
+msgstr "In NPU environments, it is recommended to use ``accelerate launch`` with FSDP 1/2 for multi-node training; this approach provides better communication and computation efficiency on NPU."
 
-#: ../../source/multibackend/npu/npu_training.rst:173 433980ddfb5c410896f729000873990e
+#: ../../source/multibackend/npu/npu_training.rst:193
+#: f816e94e5bb0406ca815747c47473335
 msgid "其他启动方式（如 ``torchrun/deepspeed``）及更多详细配置请参考 :doc:`分布式训练 <../../advanced/distributed>` 文档。"
-msgstr ""
-"For other launch methods (such as ``torchrun/deepspeed``) and more detailed configurations, refer "
-"to the :doc:`Distributed Training <../../advanced/distributed>` document."
+msgstr "For other launch methods (such as ``torchrun/deepspeed``) and more detailed configurations, refer to the :doc:`Distributed Training <../../advanced/distributed>` document."
 
-#: ../../source/multibackend/npu/npu_training.rst:175 6944959a992e427280369d6fd42dbf84
+#: ../../source/multibackend/npu/npu_training.rst:195
+#: 5284abc57f7a4953827f7d469164f0b0
 msgid "**1. 准备 Accelerate 配置文件**"
 msgstr "**1. Prepare Accelerate configuration file**"
 
-#: ../../source/multibackend/npu/npu_training.rst:177 bb48647b5d6a49aebf5b27d48ba4203b
+#: ../../source/multibackend/npu/npu_training.rst:197
+#: 3092225f87fe48eca0751d0b741f5e28
 msgid "创建或修改 ``examples/accelerate/fsdp_config.yaml``，关键参数如下（请根据实际节点数和 IP 修改）："
-msgstr ""
-"Create or modify ``examples/accelerate/fsdp_config.yaml``; key parameters are as follows (please "
-"modify according to the actual number of nodes and IP):"
+msgstr "Create or modify ``examples/accelerate/fsdp_config.yaml``; key parameters are as follows (please modify according to the actual number of nodes and IP):"
 
-#: ../../source/multibackend/npu/npu_training.rst:208 fb3dad4b60384989896952e143e050d3
+#: ../../source/multibackend/npu/npu_training.rst:228
+#: e69ac63f32ee40d281587f2dbe8c53a9
 msgid "关键多机参数说明："
 msgstr "Explanation of key multi-node parameters:"
 
-#: ../../source/multibackend/npu/npu_training.rst:210 e5a6f9431ac74a9090d5893c17be113b
+#: ../../source/multibackend/npu/npu_training.rst:230
+#: de543c1fa21849f5b23b212b987d7baa
 msgid "num_machines: 节点总数"
 msgstr "num_machines: Total number of nodes"
 
-#: ../../source/multibackend/npu/npu_training.rst:211 4e536e0b915444a0aa02d2aa085cc359
+#: ../../source/multibackend/npu/npu_training.rst:231
+#: 61b0dd7580474aafb8e11eab0d20a6b5
 msgid "num_processes: 总进程数（总卡数） = num_machines * 每台机器卡数"
-msgstr ""
-"num_processes: Total number of processes (total number of cards) = num_machines * number of cards"
-" per machine"
+msgstr "num_processes: Total number of processes (total number of cards) = num_machines * number of cards per machine"
 
-#: ../../source/multibackend/npu/npu_training.rst:212 6bc1b6c0fd9a4075975d4d436a558c86
+#: ../../source/multibackend/npu/npu_training.rst:232
+#: 07ffcbc8fc2649f786c0a5e75ce4d845
 msgid "main_process_ip: 主节点 IP 地址（所有节点需保持一致）"
 msgstr "main_process_ip: IP address of the main node (must be consistent across all nodes)"
 
-#: ../../source/multibackend/npu/npu_training.rst:213 e4bb0a5b41af4e46b3b8612dba5777e6
+#: ../../source/multibackend/npu/npu_training.rst:233
+#: 71cae942dae24923b50192a91a65a73f
 msgid "main_process_port: 主节点端口（所有节点需保持一致）"
 msgstr "main_process_port: Port of the main node (must be consistent across all nodes)"
 
-#: ../../source/multibackend/npu/npu_training.rst:214 390e5c404aac4869ac0de7631f1d18be
+#: ../../source/multibackend/npu/npu_training.rst:234
+#: c1fc8de6cb784c1f9cb588a1db235223
 msgid "machine_rank: 当前节点编号（主节点为0，从节点依次递增）"
 msgstr "machine_rank: Current node index (main node is 0, and the subsequent nodes increase in order)"
 
-#: ../../source/multibackend/npu/npu_training.rst:216 92c25a620bf3417ba5e95dd5950df2eb
+#: ../../source/multibackend/npu/npu_training.rst:236
+#: 259b77346cf6438bba377ac99551a7f9
 msgid "**2. 启动训练**"
 msgstr "**2. Launch training**"
 
-#: ../../source/multibackend/npu/npu_training.rst:218 3bef56824c9240499e006c7e520144ee
+#: ../../source/multibackend/npu/npu_training.rst:238
+#: 8d8ae36334fd4242b27cdc5c89aa5d4e
 msgid "在所有节点上执行相同的启动命令（确保 ``machine_rank`` 在 yaml 中已正确配置）："
-msgstr ""
-"Execute the same launch command on all nodes (ensure ``machine_rank`` is correctly configured in "
-"the YAML):"
+msgstr "Execute the same launch command on all nodes (ensure ``machine_rank`` is correctly configured in the YAML):"
 
-#: ../../source/multibackend/npu/npu_training.rst:228 eceb657c65f8422f8cd2dd034b4f3e33
+#: ../../source/multibackend/npu/npu_training.rst:248
+#: 7c4a757cb6874373b987cd9b0a4542bd
 msgid "训练方式"
 msgstr "Training Modes"
 
-#: ../../source/multibackend/npu/npu_training.rst:230 00a3c7bfa7844e2488c354ffcb6c109a
+#: ../../source/multibackend/npu/npu_training.rst:250
+#: 9fc7933155874a87aad1401e795958ca
 msgid "以下是常见训练场景的启动命令参考，具体参数配置文件请根据实际需求调整。"
-msgstr ""
-"The following are reference launch commands for common training scenarios; adjust the "
-"configuration files according to your needs."
+msgstr "The following are reference launch commands for common training scenarios; adjust the configuration files according to your needs."
 
-#: ../../source/multibackend/npu/npu_training.rst:233 09629affda4a434ba2e0e07193a9873a
+#: ../../source/multibackend/npu/npu_training.rst:253
+#: becc8d07e41c44b0b14bd82fa8ddaad4
 msgid "预训练 (PT)"
 msgstr "Pretraining (PT)"
 
-#: ../../source/multibackend/npu/npu_training.rst:240 9eb0eb7c818b41dba6e53337f575607b
+#: ../../source/multibackend/npu/npu_training.rst:260
+#: b427c6dbc82f4a03a24ac294876885aa
 msgid "监督微调 (SFT)"
 msgstr "Supervised Fine-tuning (SFT)"
 
-#: ../../source/multibackend/npu/npu_training.rst:247 22a448ef58294a1a8e20add993b13f3a
+#: ../../source/multibackend/npu/npu_training.rst:267
+#: 5c82f888768d4326b90669f39502fb0e
 msgid "奖励模型 (RM)"
 msgstr "Reward Model (RM)"
 
-#: ../../source/multibackend/npu/npu_training.rst:254 4b7b43f069944316988fe58e6fc4183a
+#: ../../source/multibackend/npu/npu_training.rst:274
+#: 799d48560ad7427aaa2ff68e3cf169b3
 msgid "DPO 训练"
 msgstr "DPO Training"
 
-#: ../../source/multibackend/npu/npu_training.rst:261 8a394f11861e45b58c2ef318937b5385
+#: ../../source/multibackend/npu/npu_training.rst:281
+#: 4af82cdd709744ad934b68ac69e0058d
 msgid "全参数微调 (Full)"
 msgstr "Full-parameter Fine-tuning (Full)"
 
-#: ../../source/multibackend/npu/npu_training.rst:268 7e0e65918a0748788aa4efdd04d23383
+#: ../../source/multibackend/npu/npu_training.rst:288
+#: 56be9354624d4966b0a632e4be091872
 msgid "性能优化"
 msgstr "Performance Optimization"
 
-#: ../../source/multibackend/npu/npu_training.rst:273 eaf82280ac6147ea856ec5ec217f11dc
-msgid "LLaMA-Factory 支持FA，NpuFusedRMSNorm，NpuFusedSwiGlu，NpuFusedRoPE和NpuFusedMoE融合算子。"
-msgstr ""
-"LLaMA-Factory supports FA, NpuFusedRMSNorm, NpuFusedSwiGlu, NpuFusedRoPE, and NpuFusedMoE fused "
-"operators."
+#: ../../source/multibackend/npu/npu_training.rst:293
+#: 5d4a0c2942124ed081768a16bd2cd1e5
+msgid "LlamaFactory 支持 FA、NpuFusedRMSNorm、NpuFusedSwiGlu、NpuFusedRoPE 和 NpuFusedMoE 融合算子。"
+msgstr "LlamaFactory supports FA, NpuFusedRMSNorm, NpuFusedSwiGlu, NpuFusedRoPE, and NpuFusedMoE fused operators."
 
-#: ../../source/multibackend/npu/npu_training.rst:275 bb19a40b6a30453cbb464f9a4c622e42
-msgid "可在训练脚本中配置如下参数，模型加载后替换对应模型结构，使能NpuFusedRMSNorm，NpuFusedSwiGlu，NpuFusedRoPE和NpuFusedMoE融合算子，提升训练效率。该接口使能后，代码内部自动识别是否满足模型结构替换的要求，满足的情况对应模型结构会被替换为融合算子形式。"
-msgstr ""
-"Configure the following parameter in the training script to enable NpuFusedRMSNorm, "
-"NpuFusedSwiGlu, NpuFusedRoPE, and NpuFusedMoE fused operators, replacing the corresponding model "
-"structures after loading to improve training efficiency. After enabling this interface, the code "
-"automatically determines whether the model structure meets the replacement requirements. If "
-"satisfied, the corresponding model structure will be replaced with the fused operator form."
+#: ../../source/multibackend/npu/npu_training.rst:295
+#: 0ee8e1b3b1ce47749b256e421c825f2c
+msgid "可在训练脚本中配置如下参数，模型加载后替换对应模型结构，使能NpuFusedRMSNorm、NpuFusedSwiGlu、NpuFusedRoPE和NpuFusedMoE融合算子，提升训练效率。该接口使能后，代码内部自动识别是否满足模型结构替换的要求，满足的情况对应模型结构会被替换为融合算子形式。"
+msgstr "Configure the following parameter in the training script to enable NpuFusedRMSNorm, NpuFusedSwiGlu, NpuFusedRoPE, and NpuFusedMoE fused operators, replacing the corresponding model structures after loading to improve training efficiency. After enabling this interface, the code automatically determines whether the model structure meets the replacement requirements. If satisfied, the corresponding model structure will be replaced with the fused operator form."
 
-#: ../../source/multibackend/npu/npu_training.rst:282 c3249224612145cb84b92d9369502dfe
-msgid ""
-"同时LLaMA-Factory 支持昇腾 NPU 的 FA "
-"融合算子，代码内部自动识别是否满足模型结构替换的要求，满足的情况对应模型结构会被替换为融合算子形式。在训练配置文件中设置如下参数即可使能："
-msgstr ""
-"LLaMA-Factory also supports FA fused operators on Ascend NPU. The code automatically determines "
-"whether the model structure meets the replacement requirements, and will replace the structure "
-"with the fused operator form if satisfied. Enable it by setting the following parameter in the "
-"training configuration file:"
+#: ../../source/multibackend/npu/npu_training.rst:302
+#: db27013170514e83bc1928af9d71f59a
+msgid "同时 LlamaFactory 支持昇腾 NPU 的 FA 融合算子。启用后，Transformers 会为支持的模型选择 FA Attention 后端；对于混合注意力架构，FA 仅作用于其中的 Full Attention 层。在训练配置文件中设置如下参数即可使能："
+msgstr "LlamaFactory also supports the FA fused operator on Ascend NPUs. Once enabled, Transformers selects the FA attention backend for supported models. For hybrid attention architectures, FA applies only to their Full Attention layers. Enable it by setting the following parameter in the training configuration file:"
 
-#: ../../source/multibackend/npu/npu_training.rst:288 0ec582e9450742559c822c8601c4bfea
-msgid "当前融合算子对模型的支持程度受限，该功能正在持续迭代开发中，以提升泛化性和适用性。"
-msgstr ""
-"Currently, the range of model support for fused operators is limited. This feature is under "
-"continuous development to improve generality and applicability."
+#: ../../source/multibackend/npu/npu_training.rst:308
+#: cc6c9c1026ed4fe7a8c0d02c75a80c51
+msgid "当前融合算子对模型的支持程度受限，该功能正在持续迭代开发中，以提升泛化性和适用性。当前各融合算子支持的模型系列如下："
+msgstr "Fused operator support is currently limited to certain models. This feature is under continuous development to improve generality and applicability. The model families supported by each fused operator are listed below:"
 
-#: ../../source/multibackend/npu/npu_training.rst:296 2068234000a8427da723166107bffb08
+#: ../../source/multibackend/npu/npu_training.rst:316
+#: 5eb9ce5eff1e40ee8d4ea37fbc0128a2
 msgid "支持模型系列"
 msgstr "Supported Model Series"
 
-#: ../../source/multibackend/npu/npu_training.rst:297 a4470f4f88f246aaaaa6f19e4913da25
+#: ../../source/multibackend/npu/npu_training.rst:317
+#: 7624f771fb024fac86873a94906e0a48
 msgid "FA"
 msgstr "FA"
 
-#: ../../source/multibackend/npu/npu_training.rst:298
-#: ../../source/multibackend/npu/npu_training.rst:300
-#: ../../source/multibackend/npu/npu_training.rst:302
-#: ../../source/multibackend/npu/npu_training.rst:304 821f7c4ce5da4f44ae0a09f0e7f9b7d0
-msgid "Qwen3, Qwen3-MOE, Qwen3-VL, Qwen3-VL-MOE"
-msgstr "Qwen3, Qwen3-MOE, Qwen3-VL, Qwen3-VL-MOE"
+#: ../../source/multibackend/npu/npu_training.rst:318
+#: ../../source/multibackend/npu/npu_training.rst:320
+#: ../../source/multibackend/npu/npu_training.rst:322
+#: ../../source/multibackend/npu/npu_training.rst:324
+#: 12a514455f9e4a06ad226152ece6767b 276d7dac4d794fd8bab0f11b55d6b5a9
+#: c12770bbae8c4f6c909c214ae6918930 a41b652239d2445c83e79106b5166034
+msgid "Qwen3, Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, Qwen3.5-MoE"
+msgstr "Qwen3, Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, Qwen3.5-MoE"
 
-#: ../../source/multibackend/npu/npu_training.rst:299 d09af4843ac44bb8b61c5494adf9e8aa
+#: ../../source/multibackend/npu/npu_training.rst:319
+#: b5d5b12e6933444895bfc33294e8ae69
 msgid "NpuFusedRMSNorm"
 msgstr "NpuFusedRMSNorm"
 
-#: ../../source/multibackend/npu/npu_training.rst:301 93a830e73c1c447e8cdd49c71c8e7fa7
+#: ../../source/multibackend/npu/npu_training.rst:321
+#: 9306fb66b5c84cd58522d9fd11d7acc4
 msgid "NpuFusedSwiGlu"
 msgstr "NpuFusedSwiGlu"
 
-#: ../../source/multibackend/npu/npu_training.rst:303 4a223b34c64d446390b4f101c63eb55d
+#: ../../source/multibackend/npu/npu_training.rst:323
+#: 52a9230a845742baaef735bb102b8879
 msgid "NpuFusedRoPE"
 msgstr "NpuFusedRoPE"
 
-#: ../../source/multibackend/npu/npu_training.rst:305 88edee9c1d0649b395600bce3ce12d5f
+#: ../../source/multibackend/npu/npu_training.rst:325
+#: 4ca5ba9fe096400a9d55432a8183629a
 msgid "NpuFusedMoE"
 msgstr "NpuFusedMoE"
 
-#: ../../source/multibackend/npu/npu_training.rst:306 54a2e405dc0647fdb7e81f9df63d2d15
-msgid "Qwen3-MOE，Qwen3-VL-MOE"
-msgstr "Qwen3-MOE, Qwen3-VL-MOE"
+#: ../../source/multibackend/npu/npu_training.rst:326
+#: 5901bdf0cb994fcbb1c0871c88a5c4cc
+msgid "Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL-MoE, Qwen3.5-MoE"
+msgstr "Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL-MoE, Qwen3.5-MoE"
 
-#: ../../source/multibackend/npu/npu_training.rst:310 aad62122be4a4096a31c629aebfa2851
+#: ../../source/multibackend/npu/npu_training.rst:330
+#: cfd2f1271e0641be9bfbaff70de182c6
 msgid "算子下发优化"
 msgstr "Operator Dispatch Optimization"
 
-#: ../../source/multibackend/npu/npu_training.rst:312 68e137ec3ef548129f44e1b75380602c
+#: ../../source/multibackend/npu/npu_training.rst:332
+#: 4b1b23021b9f4451ae7b3edd3a045740
 msgid "通过设置 ``TASK_QUEUE_ENABLE`` 环境变量优化算子下发性能（推荐 Level 2）："
-msgstr ""
-"Optimize operator dispatch performance by setting the ``TASK_QUEUE_ENABLE`` environment variable "
-"(Level 2 recommended):"
+msgstr "Optimize operator dispatch performance by setting the ``TASK_QUEUE_ENABLE`` environment variable (Level 2 recommended):"
 
-#: ../../source/multibackend/npu/npu_training.rst:319 636a4d6a2a3d4e86bdbcdb57ef5869a5
+#: ../../source/multibackend/npu/npu_training.rst:339
+#: c9950f169fa646febef41057f889056d
 msgid "模型保存、断点续训以及 LoRA 适配器后续合并导出，请参考 :doc:`模型保存、LoRA 合并与量化 <../../getting_started/merge_lora>`。"
-msgstr ""
-"For model saving, checkpoint resumption, and subsequent merging and export of LoRA adapters, "
-"refer to :doc:`Model Saving, LoRA Merging, and Quantization <../../getting_started/merge_lora>`."
+msgstr "For model saving, checkpoint resumption, and subsequent merging and export of LoRA adapters, refer to :doc:`Model Saving, LoRA Merging, and Quantization <../../getting_started/merge_lora>`."

--- a/docs/source/advanced/acceleration.rst
+++ b/docs/source/advanced/acceleration.rst
@@ -1,7 +1,7 @@
 加速
 =====================
 
-LLaMA-Factory 支持多种加速技术，包括：:ref:`FlashAttention <flashattn>` 、 :ref:`Unsloth <sloth>` 、 :ref:`Liger Kernel <ligerkernel>`  。
+LlamaFactory 支持多种加速技术，包括：:ref:`FlashAttention <flashattn>` 、 :ref:`Unsloth <sloth>` 、 :ref:`Liger Kernel <ligerkernel>`  。
 
 
 

--- a/docs/source/advanced/arguments.rst
+++ b/docs/source/advanced/arguments.rst
@@ -409,7 +409,7 @@ GaLore
      - False
    * - dataset_dir
      - Union[str, Dict[str, Any]]
-     - 存储数据集的文件夹路径，可以是字符串或字典。当为字符串时，表示数据集目录的路径，例如 `data <https://github.com/hiyouga/LLaMA-Factory/tree/main/data>`_ ；当为字典时，将覆盖默认从本地 `dataset_info.json <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dataset_info.json>`_ 加载的行为。
+     - 存储数据集的文件夹路径，可以是字符串或字典。当为字符串时，表示数据集目录的路径，例如 `data <https://github.com/hiyouga/LlamaFactory/tree/main/data>`_ ；当为字典时，将覆盖默认从本地 `dataset_info.json <https://github.com/hiyouga/LlamaFactory/blob/main/data/dataset_info.json>`_ 加载的行为。
      - data
    * - media_dir
      - Optional[str]
@@ -1017,7 +1017,7 @@ RAY
      - 允许在命令行中传递额外参数
    * - ``LLAMAFACTORY_VERBOSITY``
      - General
-     - 设置 LLaMA-Factory 的日志级别("DEBUG","INFO","WARN")
+     - 设置 LlamaFactory 的日志级别("DEBUG","INFO","WARN")
    * - ``USE_MODELSCOPE_HUB``
      - General
      - 优先使用 ModelScope 下载模型/数据集或使用缓存路径中的模型/数据集

--- a/docs/source/advanced/best_practice/gpt-oss.rst
+++ b/docs/source/advanced/best_practice/gpt-oss.rst
@@ -4,12 +4,12 @@ GPT-OSS
 3步实现 GPT-OSS 的 LoRA 微调
 -------------------------------------------------------
 
-1. 安装 LLaMA-Factory 和 transformers
+1. 安装 LlamaFactory 和 transformers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. code-block:: bash
 
-   git clone --depth 1 https://github.com/hiyouga/LLaMA-Factory.git
-   cd LLaMA-Factory
+   git clone --depth 1 https://github.com/hiyouga/LlamaFactory.git
+   cd LlamaFactory
    pip install -e .
    pip install -r requirements/metrics.txt --no-build-isolation
    pip install "transformers==4.55.0"

--- a/docs/source/advanced/distributed.rst
+++ b/docs/source/advanced/distributed.rst
@@ -3,7 +3,7 @@
 分布训练
 ==================
 
-LLaMA-Factory 支持单机多卡和多机多卡分布式训练。同时也支持 :ref:`DDP <NativeDDP>`、:ref:`DeepSpeed <deepspeed_ref>` 和 :ref:`FSDP <fsdp_ref>` 三种分布式引擎。
+LlamaFactory 支持单机多卡和多机多卡分布式训练。同时也支持 :ref:`DDP <NativeDDP>`、:ref:`DeepSpeed <deepspeed_ref>` 和 :ref:`FSDP <fsdp_ref>` 三种分布式引擎。
 
 
 `DDP <https://pytorch.org/docs/stable/notes/ddp.html>`__ (DistributedDataParallel) 通过实现模型并行和数据并行实现训练加速。
@@ -282,7 +282,7 @@ DeepSpeed 是由微软开发的一个开源深度学习优化库，旨在提高�
 简单来说：从 ZeRO-1 到 ZeRO-3，阶段数越高，显存需求越小，但是训练速度也依次变慢。此外，设置 ``offload_param=cpu`` 参数会大幅减小显存需求，但会极大地使训练速度减慢。因此，如果您有足够的显存，
 应当使用 ZeRO-1，并且确保 ``offload_param=none``。
 
-LLaMA-Factory提供了使用不同阶段的 DeepSpeed 配置文件的示例。包括：
+LlamaFactory提供了使用不同阶段的 DeepSpeed 配置文件的示例。包括：
 
 * :ref:`ZeRO-0` (不开启)
 * :ref:`ZeRO-2`
@@ -369,7 +369,7 @@ deepspeed
 +++++++++++++++++++++
 
 
-LLaMA-Factory 支持使用 DeepSpeed 的多机多卡训练，您可以通过以下命令启动：
+LlamaFactory 支持使用 DeepSpeed 的多机多卡训练，您可以通过以下命令启动：
 
 .. code-block:: bash
 
@@ -646,7 +646,7 @@ TP是一种重要的大模型训练内存优化技术。以往在 Hugging Face T
 FSDP
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-PyTorch 的全切片数据并行技术 `FSDP <https://pytorch.org/docs/stable/fsdp.html>`_ （Fully Sharded Data Parallel）能让我们处理更多更大的模型。LLaMA-Factory支持使用 FSDP 引擎进行分布式训练。
+PyTorch 的全切片数据并行技术 `FSDP <https://pytorch.org/docs/stable/fsdp.html>`_ （Fully Sharded Data Parallel）能让我们处理更多更大的模型。LlamaFactory支持使用 FSDP 引擎进行分布式训练。
 
 FSDP 的参数 ``ShardingStrategy`` 的不同取值决定了模型的划分方式：
 

--- a/docs/source/advanced/extras.rst
+++ b/docs/source/advanced/extras.rst
@@ -6,7 +6,7 @@ LLaMA Pro
 ----------------
 
 为了解决大语言模型的遗忘问题， LLaMA Pro 通过在原有模型上增加新模块以适应新的任务，使其在多个新任务上的表现均优于原始模型。
-LLaMA-Factory 支持 LLaMA Pro 的使用。
+LlamaFactory 支持 LLaMA Pro 的使用。
 您可以使用运行 ``expand.sh`` 将 ``Meta-Llama-3-8B-Instruct`` 扩展为 ``llama3-8b-instruct-pro``。
 
 对于 LLaMA Pro 模型进行训练时，您需要指定 ``use_llama_pro`` 为 ``true``。

--- a/docs/source/advanced/model_support.rst
+++ b/docs/source/advanced/model_support.rst
@@ -3,7 +3,7 @@
 =====================
 
 
-LLaMA-Factory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多模态模型为例，详细介绍如何为新模型添加支持。对于多模态模型，我们需要完成两个主要任务：
+LlamaFactory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多模态模型为例，详细介绍如何为新模型添加支持。对于多模态模型，我们需要完成两个主要任务：
 
 1. 注册模型的template
 2. 解析多模态数据并构建 messages
@@ -110,7 +110,7 @@ LLaMA-Factory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多
 多模态数据构建
 --------------------
 
-对于多模态模型，我们参照原始模型在 LLaMA-Factory 中实现多模态数据的解析。
+对于多模态模型，我们参照原始模型在 LlamaFactory 中实现多模态数据的解析。
 
 我们可以在 ``src/llamafactory/data/mm_plugin.py`` 中实现 ``Llama4Plugin`` 类来解析多模态数据。
 
@@ -129,13 +129,13 @@ LLaMA-Factory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多
             def get_mm_inputs(
                 ...
 
-``get_mm_inputs`` 的作用是将图像、视频等多模态数据转化为模型可以接收的输入，如 ``pixel_values``。为实现 ``get_mm_inputs``，首先我们需要检查 llama4 的 processor 是否可以与 `已有实现 <https://github.com/hiyouga/LLaMA-Factory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264>`_ 兼容。模型官方仓库中的 `processing_llama4.py <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 表明 llama4 的 processor 返回数据包含字段 ``pixel_values``，这与 LLaMA-Factory 中的已有实现兼容。因此，我们只需要参照已有的 ``get_mm_inputs`` 方法实现即可。
+``get_mm_inputs`` 的作用是将图像、视频等多模态数据转化为模型可以接收的输入，如 ``pixel_values``。为实现 ``get_mm_inputs``，首先我们需要检查 llama4 的 processor 是否可以与 `已有实现 <https://github.com/hiyouga/LlamaFactory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264>`_ 兼容。模型官方仓库中的 `processing_llama4.py <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 表明 llama4 的 processor 返回数据包含字段 ``pixel_values``，这与 LlamaFactory 中的已有实现兼容。因此，我们只需要参照已有的 ``get_mm_inputs`` 方法实现即可。
 
 .. note::
 
     .. code-block:: python
         
-        # https://github.com/hiyouga/LLaMA-Factory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264
+        # https://github.com/hiyouga/LlamaFactory/blob/da971c37640de20f97b4d774e77e6f8d5c00b40a/src/llamafactory/data/mm_plugin.py#L264
         def _get_mm_inputs(
             self,
             images: list["ImageInput"],
@@ -166,7 +166,7 @@ LLaMA-Factory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多
 
 
 
-``process_messages`` 的作用是根据输入图片/视频的大小，数量等信息在 messages 中插入相应数量的占位符，以便模型可以正确解析多模态数据。 我们需要参考 `原仓库实现 <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 以及 LLaMA-Factory 中的规范返回 ``list[dict[str, str]]`` 类型的 messages。
+``process_messages`` 的作用是根据输入图片/视频的大小，数量等信息在 messages 中插入相应数量的占位符，以便模型可以正确解析多模态数据。 我们需要参考 `原仓库实现 <https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/processing_llama4.py#L157>`_ 以及 LlamaFactory 中的规范返回 ``list[dict[str, str]]`` 类型的 messages。
 
 
 .. 测试 TODO
@@ -176,7 +176,7 @@ LLaMA-Factory 允许用户添加自定义模型支持。我们将以 LLaMA-4 多
 提供模型路径
 ---------------------
 
-最后, 在 `src/llamafactory/extras/constants.py <https://github.com/hiyouga/LLaMA-Factory/blob/main/src/llamafactory/extras/constants.py>`_ 中提供模型的下载路径。例如：
+最后, 在 `src/llamafactory/extras/constants.py <https://github.com/hiyouga/LlamaFactory/blob/main/src/llamafactory/extras/constants.py>`_ 中提供模型的下载路径。例如：
 
 .. code-block:: python 
 

--- a/docs/source/advanced/monitor.rst
+++ b/docs/source/advanced/monitor.rst
@@ -1,7 +1,7 @@
 实验监控
 ================
 
-LLaMA-Factory 支持多种训练可视化工具，包括：:ref:`LlamaBoard <LlamaBoard>` 、 :ref:`SwanLab <SwanLab>`、:ref:`TensorBoard <TensorBoard>` 、 :ref:`Wandb <Wandb>` 、 :ref:`MLflow <MLflow>` 。
+LlamaFactory 支持多种训练可视化工具，包括：:ref:`LlamaBoard <LlamaBoard>` 、 :ref:`SwanLab <SwanLab>`、:ref:`TensorBoard <TensorBoard>` 、 :ref:`Wandb <Wandb>` 、 :ref:`MLflow <MLflow>` 。
 
 LlamaBoard
 --------------------------

--- a/docs/source/advanced/tuning_algorithms.rst
+++ b/docs/source/advanced/tuning_algorithms.rst
@@ -3,7 +3,7 @@
 调优算法
 =============
 
-LLaMA-Factory 支持多种调优算法，包括： :ref:`Full Parameter Fine-tuning <full>` 、 :ref:`Freeze <Freeze>` 、 :ref:`LoRA <LoRA>` 、 :ref:`Galore <Galore>` 、 :ref:`BAdam <BAdam>` 。
+LlamaFactory 支持多种调优算法，包括： :ref:`Full Parameter Fine-tuning <full>` 、 :ref:`Freeze <Freeze>` 、 :ref:`LoRA <LoRA>` 、 :ref:`Galore <Galore>` 、 :ref:`BAdam <BAdam>` 。
 
 .. _full:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,7 +6,7 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "LLaMA Factory"
+project = "LlamaFactory"
 copyright = "2024, LlamaFactory team."
 author = "Ziyang Miao, Yaowei Zheng"
 
@@ -26,7 +26,7 @@ gettext_compact = False
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_title = "LLaMA Factory"
+html_title = "LlamaFactory"
 html_theme = "furo"
 html_static_path = ["_static"]
 html_css_files = [

--- a/docs/source/getting_started/data_preparation.rst
+++ b/docs/source/getting_started/data_preparation.rst
@@ -3,7 +3,7 @@
 数据处理
 ============================
 
-`dataset_info.json <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dataset_info.json/>`_ 包含了所有经过预处理的 **本地数据集** 以及 **在线数据集**。如果您希望使用自定义数据集，请 **务必** 在 ``dataset_info.json`` 文件中添加对数据集及其内容的定义。
+`dataset_info.json <https://github.com/hiyouga/LlamaFactory/blob/main/data/dataset_info.json/>`_ 包含了所有经过预处理的 **本地数据集** 以及 **在线数据集**。如果您希望使用自定义数据集，请 **务必** 在 ``dataset_info.json`` 文件中添加对数据集及其内容的定义。
 
 目前我们支持 :ref:`Alpaca<alpaca>` 格式和  :ref:`ShareGPT<Sharegpt>` 格式的数据集。
 
@@ -27,7 +27,7 @@ Alpaca
 指令监督微调数据集
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/alpaca_zh_demo.json/>`__
+**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/alpaca_zh_demo.json/>`__
 
 指令监督微调(Instruct Tuning)通过让模型学习详细的指令以及对应的回答来优化模型在特定指令下的表现。
 
@@ -123,7 +123,7 @@ Alpaca
 预训练数据集
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**样例数据集**： `预训练样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/c4_demo.json/>`_
+**样例数据集**： `预训练样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/c4_demo.json/>`_
 
 大语言模型通过学习未被标记的文本进行预训练，从而学习语言的表征。通常，预训练数据集从互联网上获得，因为互联网上提供了大量的不同领域的文本信息，有助于提升模型的泛化能力。
 
@@ -351,7 +351,7 @@ ShareGPT
 
 .. note::
 
-  * ShareGPT 格式中的 KTO 数据集（`样例 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/kto_en_demo.json/>`__）和多模态数据集（`样例 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/mllm_demo.json/>`__）与 Alpaca 格式的类似。
+  * ShareGPT 格式中的 KTO 数据集（`样例 <https://github.com/hiyouga/LlamaFactory/blob/main/data/kto_en_demo.json/>`__）和多模态数据集（`样例 <https://github.com/hiyouga/LlamaFactory/blob/main/data/mllm_demo.json/>`__）与 Alpaca 格式的类似。
   * 预训练数据集不支持 ShareGPT 格式。
 
 .. _指令监督微调数据集-2:
@@ -360,7 +360,7 @@ ShareGPT
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/glaive_toolcall_zh_demo.json/>`__
+**样例数据集**： `指令监督微调样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/glaive_toolcall_zh_demo.json/>`__
 
 相比 ``alpaca`` 格式的数据集， ``sharegpt`` 格式支持 **更多** 的角色种类，例如 human、gpt、observation、function 等等。它们构成一个对象列表呈现在 ``conversations`` 列中。下面是 ``sharegpt`` 格式的一个例子：
 
@@ -437,7 +437,7 @@ ShareGPT
 偏好数据集
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**样例数据集**： `偏好数据样例数据集 <https://github.com/hiyouga/LLaMA-Factory/blob/main/data/dpo_zh_demo.json/>`_
+**样例数据集**： `偏好数据样例数据集 <https://github.com/hiyouga/LlamaFactory/blob/main/data/dpo_zh_demo.json/>`_
 
 Sharegpt 格式的偏好数据集同样需要在 ``chosen`` 列中提供更优的消息，并在 ``rejected`` 列中提供更差的消息。下面是一个例子：
 

--- a/docs/source/getting_started/inference.rst
+++ b/docs/source/getting_started/inference.rst
@@ -1,7 +1,7 @@
 推理
 ==========================
 
-LLaMA-Factory 支持多种推理方式。
+LlamaFactory 支持多种推理方式。
 
 您可以使用 ``llamafactory-cli chat inference_config.yaml`` 或 ``llamafactory-cli webchat inference_config.yaml`` 进行推理与模型对话。对话时配置文件只需指定原始模型 ``model_name_or_path`` 和 ``template`` ，并根据是否是微调模型指定 ``adapter_name_or_path`` 和 ``finetuning_type``。
 

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -91,23 +91,23 @@ CUDA 安装
 .. image:: ../assets/image-20240610222021868.png
 
 
-LLaMA-Factory 安装
+LlamaFactory 安装
 -------------------------------------
 
-在安装 LLaMA-Factory 之前，请确保您安装了下列依赖:
+在安装 LlamaFactory 之前，请确保您安装了下列依赖:
 
-运行以下指令以安装 LLaMA-Factory 及其依赖:
+运行以下指令以安装 LlamaFactory 及其依赖:
 
 .. code-block:: bash
 
-  git clone --depth 1 https://github.com/hiyouga/LLaMA-Factory.git
-  cd LLaMA-Factory
+  git clone --depth 1 https://github.com/hiyouga/LlamaFactory.git
+  cd LlamaFactory
   pip install -e .
   pip install -r requirements/metrics.txt
 
 如果出现环境冲突，请尝试使用 ``pip install --no-deps -e .`` 解决
 
-LLaMA-Factory 校验
+LlamaFactory 校验
 -------------------------------
 
 完成安装后，可以通过使用 ``llamafactory-cli version`` 来快速校验安装是否成功
@@ -116,7 +116,7 @@ LLaMA-Factory 校验
 
 .. image:: ../assets/image-20240611002529453.png
 
-LLaMA-Factory 高级选项
+LlamaFactory 高级选项
 ---------------------------------
 
 Windows
@@ -151,7 +151,7 @@ Extra Dependency
     - 描述
   * - torch
     - 开源深度学习框架 PyTorch，广泛用于机器学习和人工智能研究中。
-  * - torch-npu
+  * - TorchNPU
     - PyTorch 的昇腾设备兼容包。
   * - metrics
     - 用于评估和监控机器学习模型性能。
@@ -182,4 +182,4 @@ Extra Dependency
   * - swanlab
     - 开源训练跟踪工具 SwanLab，用于记录与可视化训练过程
   * - dev
-    - 用于 LLaMA Factory 开发维护。
+    - 用于 LlamaFactory 开发维护。

--- a/docs/source/getting_started/merge_lora.rst
+++ b/docs/source/getting_started/merge_lora.rst
@@ -18,7 +18,7 @@
 Checkpoint 保存策略
 ^^^^^^^^^^^^^^^^^^^^^
 
-LLaMA-Factory 的 checkpoint 保存行为主要由以下参数控制：
+LlamaFactory 的 checkpoint 保存行为主要由以下参数控制：
 
 - ``save_strategy``：控制保存策略，通常可设为 ``steps``、``epoch`` 或 ``no``。
 - ``save_steps``：当 ``save_strategy: steps`` 时，每训练多少个 step 保存一次 checkpoint。
@@ -110,7 +110,7 @@ LoRA 合并
 
 在完成模型合并并获得完整模型后，为了优化部署效果，人们通常会基于显存占用、使用成本和推理速度等因素，选择通过量化技术对模型进行压缩，从而实现更高效的部署。
 
-量化（Quantization）通过数据精度压缩有效地减少了显存使用并加速推理。LLaMA-Factory 支持多种量化方法，包括:
+量化（Quantization）通过数据精度压缩有效地减少了显存使用并加速推理。LlamaFactory 支持多种量化方法，包括:
 
 * AQLM
 * AWQ
@@ -172,4 +172,3 @@ QLoRA 是一种在 4-bit 量化模型基础上使用 LoRA 方法进行训练的�
     export_size: 5
     export_device: cpu
     export_legacy_format: false
-

--- a/docs/source/getting_started/sft.rst
+++ b/docs/source/getting_started/sft.rst
@@ -22,7 +22,7 @@ SFT 训练
 
 .. note::
 
-  LLaMA-Factory 默认使用所有可见的计算设备。根据需求可通过 ``CUDA_VISIBLE_DEVICES`` 或 ``ASCEND_RT_VISIBLE_DEVICES`` 指定计算设备。
+  LlamaFactory 默认使用所有可见的计算设备。根据需求可通过 ``CUDA_VISIBLE_DEVICES`` 或 ``ASCEND_RT_VISIBLE_DEVICES`` 指定计算设备。
 
 .. _sft指令:
 

--- a/docs/source/getting_started/webui.rst
+++ b/docs/source/getting_started/webui.rst
@@ -1,7 +1,7 @@
 WebUI
 ========================
 
-LLaMA-Factory 支持通过 WebUI 零代码微调大语言模型。
+LlamaFactory 支持通过 WebUI 零代码微调大语言模型。
 在完成 :ref:`安装 <installation>` 后，您可以通过以下指令进入 WebUI:
 
 .. code-block:: bash

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-Welcome to LLaMA Factory!
+Welcome to LlamaFactory!
 =========================
 
 .. figure:: ./assets/logo.png
@@ -7,7 +7,7 @@ Welcome to LLaMA Factory!
   :alt: logo
 
 
-LLaMA Factory 是一个简单易用且高效的大型语言模型（Large Language Model）训练与微调平台。通过 LLaMA Factory，可以在无需编写任何代码的前提下，在本地完成上百种预训练模型的微调，框架特性包括：
+LlamaFactory 是一个简单易用且高效的大型语言模型（Large Language Model）训练与微调平台。通过 LlamaFactory，可以在无需编写任何代码的前提下，在本地完成上百种预训练模型的微调，框架特性包括：
 
 * 模型种类：LLaMA、LLaVA、Mistral、Mixtral-MoE、Qwen、Yi、Gemma、Baichuan、ChatGLM、Phi 等等。
 * 训练算法：（增量）预训练、（多模态）指令监督微调、奖励模型训练、PPO 训练、DPO 训练、KTO 训练、ORPO 训练等等。
@@ -31,7 +31,7 @@ Documentation
   getting_started/merge_lora
   getting_started/inference
   getting_started/eval
-  常见问题 <https://github.com/hiyouga/LLaMA-Factory/issues/4614>
+  常见问题 <https://github.com/hiyouga/LlamaFactory/issues/4614>
 
 .. toctree::
   :maxdepth: 3

--- a/docs/source/multibackend/npu/npu_installation.rst
+++ b/docs/source/multibackend/npu/npu_installation.rst
@@ -1,7 +1,7 @@
 NPU安装及配置
 =================
 
-本文档介绍 LLaMA-Factory 在华为昇腾 NPU 上的环境准备方式。当前主要面向 Atlas A2/A3 训练系列设备；开始安装前，请先确认硬件型号和操作系统兼容性，再根据部署方式选择后续步骤。
+本文档介绍 LlamaFactory 在华为昇腾 NPU 上的环境准备方式。当前主要面向 Atlas A2/A3 训练系列设备；开始安装前，请先确认硬件型号和操作系统兼容性，再根据部署方式选择后续步骤。
 
 硬件配套和支持的操作系统
 ------------------------
@@ -54,12 +54,12 @@ NPU安装及配置
 
 - **HDK**：固件及驱动
 - **CANN**：异构计算架构
-- **torch_npu**：PyTorch 的昇腾适配插件
+- **TorchNPU**：PyTorch 的昇腾适配插件
 
 根据安装方式不同，所需操作有所区别：
 
-- **手动安装**：需手动安装 HDK、CANN 和 torch_npu。
-- **Docker 镜像/构建**：宿主机仅需安装 HDK (驱动/固件)，CANN 和 torch_npu 已集成在镜像中。
+- **手动安装**：需手动安装 HDK、CANN 和 TorchNPU。
+- **Docker 镜像/构建**：宿主机仅需安装 HDK (驱动/固件)，CANN 和 TorchNPU 已集成在镜像中。
 
 
 .. _install_form_pip:
@@ -67,7 +67,7 @@ NPU安装及配置
 方式一：手动安装环境
 ----------------------
 
-本方式需要您手动安装 HDK、CANN 和 torch_npu。
+本方式需要您手动安装 HDK、CANN 和 TorchNPU。
 
 
 1. 版本及下载链接
@@ -85,22 +85,22 @@ NPU安装及配置
      - 链接
    * - A3
      - HDK
-     - https://www.hiascend.com/hardware/firmware-drivers/community?product=1&model=30&cann=9.0.0&driver=Ascend+HDK+26.0.RC1
+     - https://www.hiascend.com/hardware/firmware-drivers?ids=d803%2C89dda9ba9de741349efa03687a487678%2C16%2CAArch64%2Conline_Yum
    * -
      - CANN
-     - https://www.hiascend.com/developer/download/community/result?module=cann&cann=9.0.0
+     - https://www.hiascend.com/developer/download/community/result?module=cann&cann=9.1.0
    * -
-     - torch_npu
-     - 2.7.1.post4
+     - TorchNPU
+     - 2.10.0.post2
    * - A2
      - HDK
-     - https://www.hiascend.com/hardware/firmware-drivers/community?product=4&model=26&cann=9.0.0&driver=Ascend+HDK+26.0.RC1
+     - https://www.hiascend.com/hardware/firmware-drivers?ids=d802%2C26958bcc909e4cd48fa56d4c4a43ebec%2C17%2CAArch64%2Conline_Yum
    * -
      - CANN
-     - https://www.hiascend.com/developer/download/community/result?module=cann&cann=9.0.0
+     - https://www.hiascend.com/developer/download/community/result?module=cann&cann=9.1.0
    * -
-     - torch_npu
-     - 2.7.1.post4
+     - TorchNPU
+     - 2.10.0.post2
 
 2. 驱动及固件
 ~~~~~~~~~~~~~~~~~~~~
@@ -161,7 +161,7 @@ A3 内部包名类似于 ``Atlas-A3-hdk-npu-driver_25.0.rc1.3_linux-aarch64.run`
 
 请根据实际情况选择 ``.run`` 或 ``.deb`` 的 CANN 安装包，并请注意安装包对 ``aarch64`` 和 ``x86`` 做了区分。
 
-以下以 A2 系列为例。A3 系列唯一区别是 ``ops`` 包名字有所变化，可以根据链接内实际情况选择。A3 内部包名类似于 ``Ascend-cann-A3-ops_9.0.0_linux-aarch64.run``，实际安装方式没有变化。
+以下以 A2 系列为例。A3 系列唯一区别是 ``ops`` 包名字有所变化，可以根据链接内实际情况选择。A3 内部包名类似于 ``Ascend-cann-A3-ops_<version>_linux-aarch64.run``，实际安装方式没有变化。
 
 
 (1) 安装 Toolkit 开发套件
@@ -223,25 +223,25 @@ Toolkit 用于训练、推理及开发。
 
 
 
-4. torch-npu
+4. TorchNPU
 ~~~~~~~~~~~~~~~~~~~~
 
-建议在安装 LLaMA-Factory 时一并安装 ``torch-npu`` 插件，LLaMA-Factory 依赖内会持续更新稳定版本的 ``torch-npu`` 插件。
+建议在安装 LlamaFactory 时一并安装 TorchNPU 插件，LlamaFactory 依赖内会持续更新稳定版本的 TorchNPU 插件。
 
 .. code-block:: bash
 
     pip install -r requirements/npu.txt
 
-当然您也可以手动下载后安装 ``torch-npu`` 插件，例如：
+当然您也可以手动下载后安装 TorchNPU 插件，例如：
 
 .. code-block:: bash
 
-    pip install torch_npu-version-cp311-cp311-manylinux_2_17_aarch64.whl
+    pip install torch_npu-2.10.0.post2-cp312-cp312-manylinux_2_28_aarch64.whl
 
-安装 ``torch-npu`` 插件需要注意：
+安装 TorchNPU 插件需要注意：
 
-- 下载的 ``torch_npu`` 会对支持的 Python 版本做区分，请根据实际环境情况选择对应安装包，``pip install torch_npu`` 时，也会一并安装对应版本的 ``torch``。
-- 环境里安装的 ``torch-npu`` 和 ``torch`` 版本需要对齐。例如 ``torch-npu`` 版本为 ``2.7.1`` 时，``torch`` 的版本也需要为 ``2.7.1``。有时依赖互斥，安装不用依赖的过程会导致 ``torch`` 版本被更新，从而导致报错。
+- 下载的 TorchNPU 会对支持的 Python 版本做区分，请根据实际环境情况选择对应安装包，``pip install torch_npu`` 时，也会一并安装对应版本的 ``torch``。
+- 环境里安装的 TorchNPU 和 ``torch`` 版本需要对齐。例如 TorchNPU 版本为 ``2.10.0.post2`` 时，``torch`` 的版本也需要为 ``2.10.0``。有时依赖互斥，安装不用依赖的过程会导致 ``torch`` 版本被更新，从而导致报错。
 
 5. 验证安装
 ~~~~~~~~~~~~~~~~
@@ -258,7 +258,7 @@ Toolkit 用于训练、推理及开发。
 
 .. image:: ../../assets/advanced/npu-torch.png
 
-该情况说明 ``HDK``、``CANN`` 和 ``torch_npu`` 都正常安装且生效。
+该情况说明 ``HDK``、``CANN`` 和 TorchNPU 都正常安装且生效。
 
 
 
@@ -270,22 +270,55 @@ Toolkit 用于训练、推理及开发。
 .. note::
   请确保宿主机已安装固件和驱动，可参考前文进行安装。
 
-LLaMA-Factory 的官方镜像托管于 `Docker Hub <https://hub.docker.com/r/hiyouga/llamafactory/tags>`__ 和 `quay.io <https://quay.io/repository/ascend/llamafactory?tab=tags>`__，二者镜像无区别。
+LlamaFactory 的官方镜像托管于 `Docker Hub <https://hub.docker.com/r/hiyouga/llamafactory/tags>`__ 和 `quay.io <https://quay.io/repository/ascend/llamafactory?tab=tags>`__，二者镜像无区别。
 
 1. 拉取镜像
 ~~~~~~~~~~~~~~~~~~~~
 
-下载 main 分支最新镜像（请根据设备选择 A2 或 A3）。如需特定版本镜像，请访问镜像仓库查看 Tag。
+下载 main 分支最新镜像时，需要同时根据设备和容器操作系统选择 Tag。A2 镜像在 Tag 中使用芯片标识 ``910b``，A3 镜像使用 ``a3``：
+
+.. list-table::
+   :align: left
+   :widths: 15 20 30
+   :header-rows: 1
+
+   * - 硬件系列
+     - 容器操作系统
+     - Tag
+   * - A2
+     - Ubuntu 22.04
+     - ``latest-910b-ubuntu``
+   * - A3
+     - Ubuntu 22.04
+     - ``latest-a3-ubuntu``
+   * - A2
+     - openEuler 24.03
+     - ``latest-910b-openeuler``
+   * - A3
+     - openEuler 24.03
+     - ``latest-a3-openeuler``
+
+根据上表确定 Tag 后，从 Docker Hub 或 quay.io 中选择一个镜像仓库，并执行对应的一条命令将镜像拉取到本地：
 
 .. code-block:: shell
 
     # Docker Hub
-    docker pull hiyouga/llamafactory:latest-npu-a2
-    docker pull hiyouga/llamafactory:latest-npu-a3
+    docker pull hiyouga/llamafactory:latest-910b-ubuntu
+    docker pull hiyouga/llamafactory:latest-a3-ubuntu
+    docker pull hiyouga/llamafactory:latest-910b-openeuler
+    docker pull hiyouga/llamafactory:latest-a3-openeuler
 
     # quay.io
-    docker pull quay.io/ascend/llamafactory:latest-npu-a2
-    docker pull quay.io/ascend/llamafactory:latest-npu-a3
+    docker pull quay.io/ascend/llamafactory:latest-910b-ubuntu
+    docker pull quay.io/ascend/llamafactory:latest-a3-ubuntu
+    docker pull quay.io/ascend/llamafactory:latest-910b-openeuler
+    docker pull quay.io/ascend/llamafactory:latest-a3-openeuler
+
+``latest`` 镜像使用 ``latest-<910b|a3>-<ubuntu|openeuler>`` 格式，定时构建会更新这些 Tag。Release 镜像则使用包含完整版本信息的 Tag：
+
+.. code-block:: text
+
+    <LlamaFactory-version>-cann<CANN-version>-torch_npu<TorchNPU-version>-<910b|a3>-<OS-and-version>-py<Python-version>
 
 
 2. 启动容器
@@ -295,33 +328,31 @@ LLaMA-Factory 的官方镜像托管于 `Docker Hub <https://hub.docker.com/r/hiy
 
 .. code-block:: bash
 
-  CONTAINER_NAME=llama_factory_npu
-  DOCKER_IMAGE=hiyouga/llamafactory:latest-npu-a2
+    CONTAINER_NAME=llamafactory-npu
+    DOCKER_IMAGE=hiyouga/llamafactory:latest-910b-ubuntu
 
-  docker run -itd \
-      --cap-add=SYS_PTRACE \
-      --net=host \
-      --device=/dev/davinci0 \
-      --device=/dev/davinci1 \
-      --device=/dev/davinci2 \
-      --device=/dev/davinci3 \
-      --device=/dev/davinci4 \
-      --device=/dev/davinci5 \
-      --device=/dev/davinci6 \
-      --device=/dev/davinci7 \
-      --device=/dev/davinci_manager \
-      --device=/dev/devmm_svm \
-      --device=/dev/hisi_hdc \
-      --shm-size=1200g \
-      -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-      -v /usr/local/dcmi:/usr/local/dcmi \
-      -v /etc/ascend_install.info:/etc/ascend_install.info \
-      -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-      -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
-      -v /data:/data \
-      --name "$CONTAINER_NAME" \
-      "$DOCKER_IMAGE" \
-      /bin/bash
+    docker run -itd \
+        --net=host \
+        --device=/dev/davinci0 \
+        --device=/dev/davinci1 \
+        --device=/dev/davinci2 \
+        --device=/dev/davinci3 \
+        --device=/dev/davinci4 \
+        --device=/dev/davinci5 \
+        --device=/dev/davinci6 \
+        --device=/dev/davinci7 \
+        --device=/dev/davinci_manager \
+        --device=/dev/devmm_svm \
+        --device=/dev/hisi_hdc \
+        --shm-size=1200g \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+        -v /data:/data \
+        --name "$CONTAINER_NAME" \
+        "$DOCKER_IMAGE" \
+        /bin/bash
 
 .. note::
 
@@ -330,18 +361,29 @@ LLaMA-Factory 的官方镜像托管于 `Docker Hub <https://hub.docker.com/r/hiy
     **注意**：若未配置该参数，可能会出现首个容器占用后，后续容器因无权限而无法读取设备的情况。鉴于特权模式的权限过大，生产环境中请务必评估安全风险后慎重使用。
 
 
-3. 进入容器
+3. 验证容器环境
 ~~~~~~~~~~~~~~~~~~~~
+
+容器启动后，进入容器：
 
 .. code-block:: bash
 
-   docker exec -it llama_factory_npu bash
+    docker exec -it llamafactory-npu /bin/bash
+
+然后加载 Ascend 环境，并检查软件版本、NPU 可用性与 LlamaFactory 命令：
+
+.. code-block:: bash
+
+    source /usr/local/Ascend/ascend-toolkit/set_env.sh
+    npu-smi info
+    python -c "import torch, torch_npu; print(torch.__version__, torch_npu.__version__, torch.npu.is_available())"
+    llamafactory-cli help
 
 .. note::
 
-   通过 ``--device /dev/davinci<N>`` 挂载指定 NPU 卡（支持 0-7）。容器内设备编号会自动重新映射（例如物理机 davinci6 代表容器内设备 0）。
+   部分驱动环境中的 ``npu-smi`` 位于 ``/usr/local/sbin/npu-smi``，此时需要调整挂载源路径。通过 ``--device=/dev/davinci<N>`` 可挂载更多 NPU 设备。容器内设备编号会自动重新映射（例如物理机 davinci6 代表容器内设备 0）。
 
-进入容器后，可使用 ``llamafactory-cli train`` 启动训练；如果当前 shell 尚未加载 Ascend 环境变量，请先执行 ``source /usr/local/Ascend/ascend-toolkit/set_env.sh``。
+环境验证通过后，可直接使用 ``llamafactory-cli train`` 启动训练。
 
 .. _install_form_docker:
 
@@ -351,7 +393,7 @@ LLaMA-Factory 的官方镜像托管于 `Docker Hub <https://hub.docker.com/r/hiy
 .. note::
   请确保宿主机已安装固件和驱动。
 
-LLaMA-Factory 提供 :ref:`docker_build` 和 :ref:`docker_compose` 两种构建方式。
+LlamaFactory 提供 :ref:`docker_build` 和 :ref:`docker_compose` 两种构建方式。
 
 
 .. _docker_build:
@@ -359,62 +401,64 @@ LLaMA-Factory 提供 :ref:`docker_build` 和 :ref:`docker_compose` 两种构建�
 1. 使用 Docker Build 构建
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-(1) 构建镜像，在项目根目录下执行：
+在项目根目录下执行以下命令，构建 A2 Ubuntu 镜像：
 
-    .. code-block:: shell
+.. code-block:: shell
 
-      # Ascend-A2
-      docker build -f ./docker/docker-npu/Dockerfile --build-arg INSTALL_DEEPSPEED=false --build-arg PIP_INDEX=https://pypi.org/simple -t llamafactory:latest .
+    docker build \
+        -f ./docker/docker-npu/Dockerfile \
+        --build-arg BASE_IMAGE=quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12 \
+        --build-arg PIP_INDEX=https://pypi.org/simple \
+        -t llamafactory:npu-910b-ubuntu \
+        .
 
-      # Ascend-A3
-      docker build -f ./docker/docker-npu/Dockerfile --build-arg BASE_IMAGE=quay.io/ascend/cann:9.0.0-a3-ubuntu22.04-py3.11 --build-arg INSTALL_DEEPSPEED=false --build-arg PIP_INDEX=https://pypi.org/simple -t llamafactory:latest .
+Dockerfile 默认使用 A2 Ubuntu 基础镜像。如需构建其他组合，可以替换 ``BASE_IMAGE`` 和本地镜像 Tag：
 
-.. note::
+.. list-table::
+   :align: left
+   :widths: 15 20 55
+   :header-rows: 1
 
-    可修改 ``BASE_IMAGE`` 参数指定其他 CANN 版本（参考 `ascend/cann <https://quay.io/repository/ascend/cann?tab=tags&tag=latest>`__ ）。
+   * - 硬件系列
+     - 容器操作系统
+     - ``BASE_IMAGE``
+   * - A2
+     - Ubuntu 22.04
+     - ``quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12``
+   * - A3
+     - Ubuntu 22.04
+     - ``quay.io/ascend/cann:9.1.0-a3-ubuntu22.04-py3.12``
+   * - A2
+     - openEuler 24.03
+     - ``quay.io/ascend/cann:9.1.0-910b-openeuler24.03-py3.12``
+   * - A3
+     - openEuler 24.03
+     - ``quay.io/ascend/cann:9.1.0-a3-openeuler24.03-py3.12``
 
-(2) 启动容器
+可用的 Dockerfile 构建参数如下：
 
-    .. code-block:: shell
+.. list-table::
+   :align: left
+   :widths: 20 35 45
+   :header-rows: 1
 
-      CONTAINER_NAME=llama_factory_npu
-      DOCKER_IMAGE=llamafactory:latest
-      docker run -itd \
-          --cap-add=SYS_PTRACE \
-          --net=host \
-          --device=/dev/davinci0 \
-          --device=/dev/davinci1 \
-          --device=/dev/davinci2 \
-          --device=/dev/davinci3 \
-          --device=/dev/davinci4 \
-          --device=/dev/davinci5 \
-          --device=/dev/davinci6 \
-          --device=/dev/davinci7 \
-          --device=/dev/davinci_manager \
-          --device=/dev/devmm_svm \
-          --device=/dev/hisi_hdc \
-          --shm-size=1200g \
-          -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
-          -v /usr/local/dcmi:/usr/local/dcmi \
-          -v /etc/ascend_install.info:/etc/ascend_install.info \
-          -v /sys/fs/cgroup:/sys/fs/cgroup:ro \
-          -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
-          -v /data:/data \
-          --name "$CONTAINER_NAME" \
-          "$DOCKER_IMAGE" \
-          /bin/bash
+   * - 参数
+     - 默认值
+     - 用途
+   * - ``BASE_IMAGE``
+     - ``quay.io/ascend/cann:9.1.0-910b-ubuntu22.04-py3.12``
+     - 根据设备型号和容器操作系统选择对应的基础镜像
+   * - ``PIP_INDEX``
+     - ``https://pypi.org/simple``
+     - 指定 Python 软件包索引
+   * - ``PYTORCH_INDEX``
+     - ``https://download.pytorch.org/whl/cpu``
+     - 指定配合 TorchNPU 使用的 PyTorch wheel 索引
+   * - ``HTTP_PROXY``
+     - 空
+     - 配置构建期间使用的 HTTP/HTTPS 代理
 
-.. note::
-
-    配置 ``--privileged=true`` 可开启特权模式，赋予容器对底层硬件管理设备（如 ``/dev/davinci_manager``）的完整访问权限。这能解决多容器并行场景下，因权限限制导致的驱动初始化失败问题，确保 NPU 资源能被多个容器正常复用。
-
-    **注意**：若未配置该参数，可能会出现首个容器占用后，后续容器因无权限而无法读取设备的情况。鉴于特权模式的权限过大，生产环境中请务必评估安全风险后慎重使用。
-
-(3) 进入容器
-
-    .. code-block:: shell
-
-      docker exec -it llama_factory_npu bash
+构建完成后，可以复用 :ref:`use_form_docker` 中的 ``docker run`` 命令，并将 ``DOCKER_IMAGE`` 设置为构建时通过 ``-t`` 指定的本地镜像名称。
 
 
 .. _docker_compose:
@@ -428,22 +472,39 @@ LLaMA-Factory 提供 :ref:`docker_build` 和 :ref:`docker_compose` 两种构建�
 
   cd docker/docker-npu
 
-(2) 构建镜像并直接启动容器，请根据设备型号选择命令：
+(2) 启动容器。若本地镜像不存在，Docker Compose 会先构建镜像。请根据设备型号和容器操作系统选择 profile：
 
 .. code-block:: shell
 
-  # Ascend-A2
-  docker-compose up -d
+  # A2 + Ubuntu
+  docker compose --profile a2-ubuntu up -d
 
-  # Ascend-A3
-  docker-compose --profile a3 up -d llamafactory-a3
+  # A3 + Ubuntu
+  docker compose --profile a3-ubuntu up -d
+
+  # A2 + openEuler
+  docker compose --profile a2-openeuler up -d
+
+  # A3 + openEuler
+  docker compose --profile a3-openeuler up -d
 
 (3) 进入容器
 
 .. code-block:: shell
 
-    docker exec -it llamafactory-a2 bash
+  # A2 + Ubuntu
+  docker exec -it llamafactory-910b-ubuntu /bin/bash
+
+  # A3 + Ubuntu
+  docker exec -it llamafactory-a3-ubuntu /bin/bash
+
+  # A2 + openEuler
+  docker exec -it llamafactory-910b-openeuler /bin/bash
+
+  # A3 + openEuler
+  docker exec -it llamafactory-a3-openeuler /bin/bash
+
+如果只需要构建镜像而不启动容器，可以使用 ``docker compose --profile <profile> build``。
 
 .. note::
-
-  构建前，请检查 `docker-compose.yml` 中的 `devices` 列表，当前构建时只会挂卡 0，请根据需要做修改。
+  构建前，请检查 ``docker-compose.yml`` 中的 ``devices`` 列表，当前默认只会挂载卡 0，请根据需要修改。

--- a/docs/source/multibackend/npu/npu_training.rst
+++ b/docs/source/multibackend/npu/npu_training.rst
@@ -1,12 +1,12 @@
 NPU训练
 ================
 
-本文档介绍如何在华为昇腾 NPU 上进行 LLaMA-Factory 模型训练。
+本文档介绍如何在华为昇腾 NPU 上进行 LlamaFactory 模型训练。
 
 支持设备
 --------
 
-LLaMA-Factory 当前已适配以下昇腾 NPU 设备：
+LlamaFactory 当前已适配以下昇腾 NPU 设备：
 
 - **Atlas A2 训练系列**
 - **Atlas A3 训练系列**
@@ -60,7 +60,7 @@ LLaMA-Factory 当前已适配以下昇腾 NPU 设备：
      - 已支持
    * - **加速**
      - 融合算子
-     - 当前已支持NpuFusedRMSNorm，NpuFusedSwiGlu，NpuFusedRoPE，NpuFusedMoE
+     - 当前已支持 FA、NpuFusedRMSNorm、NpuFusedSwiGlu、NpuFusedRoPE、NpuFusedMoE
 
 .. note::
    NPU 的大部分使用方式与 GPU 保持一致。关于通用的安装步骤，请参考 :doc:`NPU 安装及配置 <npu_installation>`；关于通用的分布式训练（如 FSDP、FSDP2，DeepSpeed）配置，请参考 :doc:`分布式训练 <../../advanced/distributed>`。
@@ -68,7 +68,7 @@ LLaMA-Factory 当前已适配以下昇腾 NPU 设备：
 快速开始
 --------
 
-为了快速上手，建议直接使用 LLaMA-Factory 提供的 Docker 镜像。
+为了快速上手，建议直接使用 LlamaFactory 提供的 Docker 镜像。以下示例使用 A2 Ubuntu 镜像 ``latest-910b-ubuntu``；其他硬件和容器操作系统组合请参考 :doc:`NPU 安装及配置 <npu_installation>`。
 
 1. **启动容器** (请根据实际情况修改 ``device`` 映射)：
 
@@ -82,12 +82,20 @@ LLaMA-Factory 当前已适配以下昇腾 NPU 设备：
          --device=/dev/devmm_svm \
          --device=/dev/hisi_hdc \
          --shm-size=1200g \
+         -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+         -v /usr/local/dcmi:/usr/local/dcmi \
+         -v /etc/ascend_install.info:/etc/ascend_install.info \
          -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
-         --name llama_factory_npu \
-         hiyouga/llamafactory:latest-npu-a2 \
+         -v /data:/data \
+         --name llamafactory-npu \
+         hiyouga/llamafactory:latest-910b-ubuntu \
          /bin/bash
 
-2. **配置环境变量**：
+2. **进入容器并配置环境变量**：
+
+   .. code-block:: bash
+
+      docker exec -it llamafactory-npu /bin/bash
 
    进入容器后，**务必** 先加载 Ascend 环境配置，否则无法识别 NPU 设备：
 
@@ -282,22 +290,22 @@ DPO 训练
 融合算子
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-LLaMA-Factory 支持FA，NpuFusedRMSNorm，NpuFusedSwiGlu，NpuFusedRoPE和NpuFusedMoE融合算子。
+LlamaFactory 支持 FA、NpuFusedRMSNorm、NpuFusedSwiGlu、NpuFusedRoPE 和 NpuFusedMoE 融合算子。
 
-可在训练脚本中配置如下参数，模型加载后替换对应模型结构，使能NpuFusedRMSNorm，NpuFusedSwiGlu，NpuFusedRoPE和NpuFusedMoE融合算子，提升训练效率。该接口使能后，代码内部自动识别是否满足模型结构替换的要求，满足的情况对应模型结构会被替换为融合算子形式。
+可在训练脚本中配置如下参数，模型加载后替换对应模型结构，使能NpuFusedRMSNorm、NpuFusedSwiGlu、NpuFusedRoPE和NpuFusedMoE融合算子，提升训练效率。该接口使能后，代码内部自动识别是否满足模型结构替换的要求，满足的情况对应模型结构会被替换为融合算子形式。
 
 .. code-block:: yaml
 
    use_v1_kernels: true
 
 
-同时LLaMA-Factory 支持昇腾 NPU 的 FA 融合算子，代码内部自动识别是否满足模型结构替换的要求，满足的情况对应模型结构会被替换为融合算子形式。在训练配置文件中设置如下参数即可使能：
+同时 LlamaFactory 支持昇腾 NPU 的 FA 融合算子。启用后，Transformers 会为支持的模型选择 FA Attention 后端；对于混合注意力架构，FA 仅作用于其中的 Full Attention 层。在训练配置文件中设置如下参数即可使能：
 
 .. code-block:: yaml
 
    flash_attn: fa2
 
-当前融合算子对模型的支持程度受限，该功能正在持续迭代开发中，以提升泛化性和适用性。
+当前融合算子对模型的支持程度受限，该功能正在持续迭代开发中，以提升泛化性和适用性。当前各融合算子支持的模型系列如下：
 
 .. list-table::
    :align: left
@@ -307,15 +315,15 @@ LLaMA-Factory 支持FA，NpuFusedRMSNorm，NpuFusedSwiGlu，NpuFusedRoPE和NpuFu
    * - 融合算子
      - 支持模型系列
    * - FA
-     - Qwen3, Qwen3-MOE, Qwen3-VL, Qwen3-VL-MOE
+     - Qwen3, Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, Qwen3.5-MoE
    * - NpuFusedRMSNorm
-     - Qwen3, Qwen3-MOE, Qwen3-VL, Qwen3-VL-MOE
+     - Qwen3, Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, Qwen3.5-MoE
    * - NpuFusedSwiGlu
-     - Qwen3, Qwen3-MOE, Qwen3-VL, Qwen3-VL-MOE
+     - Qwen3, Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, Qwen3.5-MoE
    * - NpuFusedRoPE
-     - Qwen3, Qwen3-MOE, Qwen3-VL, Qwen3-VL-MOE
+     - Qwen3, Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL, Qwen3-VL-MoE, Qwen3.5, Qwen3.5-MoE
    * - NpuFusedMoE
-     - Qwen3-MOE，Qwen3-VL-MOE
+     - Qwen3-MoE, Qwen3-Next, Qwen3-Omni-MoE, Qwen3-Omni-MoE-Thinker, Qwen3-VL-MoE, Qwen3.5-MoE
 
 
 算子下发优化


### PR DESCRIPTION
## What does this PR do?

- Update the NPU installation guide for CANN 9.1.0 and TorchNPU 2.10.0.post2.
- Improve Docker instructions for A2/A3 devices with Ubuntu and openEuler images.
- Update the supported FA and NPU fused operators and their compatible model families.
- Rename product references from LLaMA-Factory to LlamaFactory.
- Update the product name from torch_npu to TorchNPU in descriptive text.